### PR TITLE
Save current layout on Practice screen to local storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Install dependencies:
 npm install
 ```
 
-Install Git Hooks
-```shell
-npm run postinstall
-```
-
-
 Create your own config file by copying `.env.example` to either `.env` or to a global location `/etc/keybr/env`. The latter is better because it allows you to run scripts from any location, not only from the root directory of the repository.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Install dependencies:
 npm install
 ```
 
+Install Git Hooks
+```shell
+npm run postinstall
+```
+
+
 Create your own config file by copying `.env.example` to either `.env` or to a global location `/etc/keybr/env`. The latter is better because it allows you to run scripts from any location, not only from the root directory of the repository.
 
 ```shell

--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -35,7 +35,7 @@ type DisplayLayout = "normal" | "compact" | "bare";
 
 export class Presenter extends PureComponent<Props, State> {
   override state: State = {
-    layout: "normal",
+    layout: getLayoutFromStorageOrDefault(),
     tour: false,
     focus: false,
     depressedKeys: [],
@@ -216,9 +216,11 @@ export class Presenter extends PureComponent<Props, State> {
 
   private handleLayout = (): void => {
     this.setState(
-      ({ layout }) => ({
-        layout: nextLayout(layout),
-      }),
+      ({ layout }) => {
+        const next_layout = nextLayout(layout);
+        localStorage.setItem("presenter-layout", next_layout);
+        return { layout: next_layout };
+      },
       () => {
         this.props.onReset();
       },
@@ -339,6 +341,23 @@ function nextLayout(layout: DisplayLayout): DisplayLayout {
     case "bare":
       return "normal";
     default:
+      return "normal";
+  }
+}
+
+/**
+ *
+ * @returns The layout stored in local storage, or "normal" if no layout is stored.
+ */
+function getLayoutFromStorageOrDefault(): DisplayLayout {
+  const layout = localStorage.getItem("presenter-layout");
+  switch (layout) {
+    case "normal":
+    case "compact":
+    case "bare":
+      return layout;
+    default:
+      localStorage.setItem("presenter-layout", "normal");
       return "normal";
   }
 }


### PR DESCRIPTION
Adding this so that when a use reloads the website, their preferred layout is set by default