### PR TITLE
feat(modifier-key): CapsLock and NumLock state

### DIFF
--- a/packages/keybr-textinput-events/lib/TextEvents.tsx
+++ b/packages/keybr-textinput-events/lib/TextEvents.tsx
@@ -226,28 +226,17 @@ export class TextEvents extends PureComponent<Props> {
   }
 }
 
-function toKeyEvent(
-  {
-    code,
-    key,
-    shiftKey,
-    altKey,
-    ctrlKey,
-    metaKey,
-    location,
-    repeat,
-  }: KeyboardEvent,
-  timeStamp: number,
-): KeyEvent {
-  return {
-    timeStamp,
-    code,
-    key,
-    shiftKey,
-    altKey,
-    ctrlKey,
-    metaKey,
-    location,
-    repeat,
-  };
+/**
+ * Process keyboard event by adding timestamp.
+ * @param ev
+ * @param timeStamp
+ * @returns Original keyboard event with a timestamp
+ */
+function toKeyEvent(ev: KeyboardEvent, timeStamp: number): KeyEvent {
+  const keyEvent = ev as KeyEvent;
+  Object.defineProperty(keyEvent, "timeStamp", {
+    value: timeStamp,
+    writable: false,
+  });
+  return keyEvent;
 }

--- a/packages/keybr-textinput-events/lib/TextEvents.tsx
+++ b/packages/keybr-textinput-events/lib/TextEvents.tsx
@@ -226,17 +226,22 @@ export class TextEvents extends PureComponent<Props> {
   }
 }
 
-/**
- * Process keyboard event by adding timestamp.
- * @param ev
- * @param timeStamp
- * @returns Original keyboard event with a timestamp
- */
 function toKeyEvent(ev: KeyboardEvent, timeStamp: number): KeyEvent {
-  const keyEvent = ev as KeyEvent;
-  Object.defineProperty(keyEvent, "timeStamp", {
-    value: timeStamp,
-    writable: false,
-  });
-  return keyEvent;
+  const { code, key, shiftKey, altKey, ctrlKey, metaKey, location, repeat } =
+    ev;
+  const modifierKeys = ["CapsLock", "NumLock"];
+  const modifiers = modifierKeys.filter((key) => ev.getModifierState(key));
+
+  return {
+    timeStamp,
+    code,
+    key,
+    shiftKey,
+    altKey,
+    ctrlKey,
+    metaKey,
+    location,
+    repeat,
+    modifiers,
+  };
 }

--- a/packages/keybr-textinput-events/lib/emulation.ts
+++ b/packages/keybr-textinput-events/lib/emulation.ts
@@ -51,36 +51,17 @@ export function newLayoutEmulator(
   };
 }
 
-function remap(
-  layout: Keyboard,
-  {
-    timeStamp,
-    code,
-    key,
-    shiftKey,
-    altKey,
-    ctrlKey,
-    metaKey,
-    location,
-    repeat,
-  }: KeyEvent,
-): KeyEvent {
+function remap(layout: Keyboard, keyEvent: KeyEvent): KeyEvent {
+  const { code, shiftKey, altKey } = keyEvent;
   const layoutKey = layout.getKey(code);
   if (layoutKey != null) {
     const codePoint = layoutKey.codePoint(KeyModifier.of({ shiftKey, altKey }));
     if (codePoint > 0) {
-      key = String.fromCodePoint(codePoint);
+      Object.defineProperty(keyEvent, "key", {
+        value: String.fromCodePoint(codePoint),
+        writable: false,
+      });
     }
   }
-  return {
-    timeStamp,
-    code,
-    key,
-    shiftKey,
-    altKey,
-    ctrlKey,
-    metaKey,
-    location,
-    repeat,
-  };
+  return keyEvent;
 }

--- a/packages/keybr-textinput-events/lib/emulation.ts
+++ b/packages/keybr-textinput-events/lib/emulation.ts
@@ -51,17 +51,38 @@ export function newLayoutEmulator(
   };
 }
 
-function remap(layout: Keyboard, keyEvent: KeyEvent): KeyEvent {
-  const { code, shiftKey, altKey } = keyEvent;
+function remap(
+  layout: Keyboard,
+  {
+    timeStamp,
+    code,
+    key,
+    shiftKey,
+    altKey,
+    ctrlKey,
+    metaKey,
+    location,
+    repeat,
+    modifiers,
+  }: KeyEvent,
+): KeyEvent {
   const layoutKey = layout.getKey(code);
   if (layoutKey != null) {
     const codePoint = layoutKey.codePoint(KeyModifier.of({ shiftKey, altKey }));
     if (codePoint > 0) {
-      Object.defineProperty(keyEvent, "key", {
-        value: String.fromCodePoint(codePoint),
-        writable: false,
-      });
+      key = String.fromCodePoint(codePoint);
     }
   }
-  return keyEvent;
+  return {
+    timeStamp,
+    code,
+    key,
+    shiftKey,
+    altKey,
+    ctrlKey,
+    metaKey,
+    location,
+    repeat,
+    modifiers,
+  };
 }

--- a/packages/keybr-textinput-events/lib/types.ts
+++ b/packages/keybr-textinput-events/lib/types.ts
@@ -21,5 +21,5 @@ export type KeyEvent = {
   readonly metaKey: boolean;
   readonly location: number;
   readonly repeat: boolean;
-  readonly getModifierState: (keyArg: string) => boolean;
+  readonly modifiers: readonly string[];
 };

--- a/packages/keybr-textinput-events/lib/types.ts
+++ b/packages/keybr-textinput-events/lib/types.ts
@@ -21,4 +21,5 @@ export type KeyEvent = {
   readonly metaKey: boolean;
   readonly location: number;
   readonly repeat: boolean;
+  readonly getModifierState: (keyArg: string) => boolean;
 };

--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -166,10 +166,21 @@ export class Presenter extends PureComponent<Props, State> {
   };
 
   private handleKeyDown = (ev: KeyEvent): void => {
+    const modifierKeys = ["CapsLock", "NumLock"];
+
     if (this.state.focus) {
-      this.setState(({ depressedKeys }) => ({
-        depressedKeys: addKey(depressedKeys, ev.code),
-      }));
+      if (modifierKeys.includes(ev.code)) {
+        const state = ev.getModifierState(ev.code);
+        this.setState(({ depressedKeys }) => ({
+          depressedKeys: state
+            ? addKey(depressedKeys, ev.code)
+            : deleteKey(depressedKeys, ev.code),
+        }));
+      } else {
+        this.setState(({ depressedKeys }) => ({
+          depressedKeys: addKey(depressedKeys, ev.code),
+        }));
+      }
       this.props.onKeyDown(ev);
     }
   };

--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -166,21 +166,20 @@ export class Presenter extends PureComponent<Props, State> {
   };
 
   private handleKeyDown = (ev: KeyEvent): void => {
-    const modifierKeys = ["CapsLock", "NumLock"];
+    // const modifierKeys = new Set(["CapsLock", "NumLock"]);
 
     if (this.state.focus) {
-      if (modifierKeys.includes(ev.code)) {
-        const state = ev.getModifierState(ev.code);
-        this.setState(({ depressedKeys }) => ({
-          depressedKeys: state
-            ? addKey(depressedKeys, ev.code)
-            : deleteKey(depressedKeys, ev.code),
-        }));
-      } else {
-        this.setState(({ depressedKeys }) => ({
-          depressedKeys: addKey(depressedKeys, ev.code),
-        }));
-      }
+      this.setState(({ depressedKeys }) => {
+        if (ev.modifiers.includes(ev.code)) {
+          return {
+            depressedKeys: addKey(depressedKeys, ev.code),
+          };
+        } else {
+          return {
+            depressedKeys: deleteKey(depressedKeys, ev.code),
+          };
+        }
+      });
       this.props.onKeyDown(ev);
     }
   };

--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -29,6 +29,7 @@ type State = {
   readonly tour: boolean;
   readonly focus: boolean;
   readonly depressedKeys: readonly string[];
+  readonly modifierKeys: readonly string[];
 };
 
 type DisplayLayout = "normal" | "compact" | "bare";
@@ -39,6 +40,7 @@ export class Presenter extends PureComponent<Props, State> {
     tour: false,
     focus: false,
     depressedKeys: [],
+    modifierKeys: ["CapsLock", "NumLock"],
   };
 
   override componentDidMount(): void {
@@ -166,29 +168,48 @@ export class Presenter extends PureComponent<Props, State> {
   };
 
   private handleKeyDown = (ev: KeyEvent): void => {
-    // const modifierKeys = new Set(["CapsLock", "NumLock"]);
-
     if (this.state.focus) {
-      this.setState(({ depressedKeys }) => {
-        if (ev.modifiers.includes(ev.code)) {
-          return {
-            depressedKeys: addKey(depressedKeys, ev.code),
-          };
-        } else {
-          return {
-            depressedKeys: deleteKey(depressedKeys, ev.code),
-          };
+      if (this.state.modifierKeys.includes(ev.code)) {
+        if (/Mac/.test(navigator.userAgent)) {
+          if (ev.modifiers.includes(ev.code)) {
+            this.setState(({ depressedKeys }) => ({
+              depressedKeys: addKey(depressedKeys, ev.code),
+            }));
+          } else {
+            this.setState(({ depressedKeys }) => ({
+              depressedKeys: deleteKey(depressedKeys, ev.code),
+            }));
+          }
         }
-      });
+      } else {
+        this.setState(({ depressedKeys }) => ({
+          depressedKeys: addKey(depressedKeys, ev.code),
+        }));
+      }
+
       this.props.onKeyDown(ev);
     }
   };
 
   private handleKeyUp = (ev: KeyEvent): void => {
     if (this.state.focus) {
-      this.setState(({ depressedKeys }) => ({
-        depressedKeys: deleteKey(depressedKeys, ev.code),
-      }));
+      if (this.state.modifierKeys.includes(ev.code)) {
+        if (/Linux|Windows/.test(navigator.userAgent)) {
+          if (this.state.depressedKeys.includes(ev.code)) {
+            this.setState(({ depressedKeys }) => ({
+              depressedKeys: deleteKey(depressedKeys, ev.code),
+            }));
+          } else {
+            this.setState(({ depressedKeys }) => ({
+              depressedKeys: addKey(depressedKeys, ev.code),
+            }));
+          }
+        }
+      } else {
+        this.setState(({ depressedKeys }) => ({
+          depressedKeys: deleteKey(depressedKeys, ev.code),
+        }));
+      }
       this.props.onKeyUp(ev);
     }
   };

--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -204,6 +204,10 @@ export class Presenter extends PureComponent<Props, State> {
               depressedKeys: addKey(depressedKeys, ev.code),
             }));
           }
+        } else if (/Mac/.test(navigator.userAgent)) {
+          this.setState(({ depressedKeys }) => ({
+            depressedKeys: deleteKey(depressedKeys, ev.code),
+          }));
         }
       } else {
         this.setState(({ depressedKeys }) => ({

--- a/packages/page-practice/lib/settings/KeyboardSettings.tsx
+++ b/packages/page-practice/lib/settings/KeyboardSettings.tsx
@@ -156,7 +156,11 @@ function useDepressedKeys(): readonly string[] {
 
   useWindowEvent("keydown", (ev) => {
     if (modifierKeys.current.includes(ev.code)) {
-      if (ev.getModifierState(ev.code)) {
+      const modifiers = modifierKeys.current.filter((key) =>
+        ev.getModifierState(key),
+      );
+      console.log(modifiers);
+      if (modifiers.includes(ev.code)) {
         setDepressedKeys(addKey(depressedKeys, ev.code));
       } else {
         setDepressedKeys(deleteKey(depressedKeys, ev.code));

--- a/packages/page-practice/lib/settings/KeyboardSettings.tsx
+++ b/packages/page-practice/lib/settings/KeyboardSettings.tsx
@@ -16,7 +16,7 @@ import {
   OptionList,
   useWindowEvent,
 } from "@keybr/widget";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 export function KeyboardSettings(): ReactNode {
@@ -146,10 +146,24 @@ function KeyboardPreview(): ReactNode {
   );
 }
 
+/**
+ * Handle modifier keys only on keydown event for os and
+ * browser compatibility.
+ */
 function useDepressedKeys(): readonly string[] {
   const [depressedKeys, setDepressedKeys] = useState<readonly string[]>([]);
+  const modifierKeys = useRef(["CapsLock", "NumLock"]);
+
   useWindowEvent("keydown", (ev) => {
-    setDepressedKeys(addKey(depressedKeys, ev.code));
+    if (modifierKeys.current.includes(ev.code)) {
+      if (ev.getModifierState(ev.code)) {
+        setDepressedKeys(addKey(depressedKeys, ev.code));
+      } else {
+        setDepressedKeys(deleteKey(depressedKeys, ev.code));
+      }
+    } else {
+      setDepressedKeys(addKey(depressedKeys, ev.code));
+    }
   });
   useWindowEvent("keyup", (ev) => {
     setDepressedKeys(deleteKey(depressedKeys, ev.code));

--- a/packages/page-practice/lib/settings/KeyboardSettings.tsx
+++ b/packages/page-practice/lib/settings/KeyboardSettings.tsx
@@ -156,21 +156,36 @@ function useDepressedKeys(): readonly string[] {
 
   useWindowEvent("keydown", (ev) => {
     if (modifierKeys.current.includes(ev.code)) {
-      const modifiers = modifierKeys.current.filter((key) =>
-        ev.getModifierState(key),
-      );
-      console.log(modifiers);
-      if (modifiers.includes(ev.code)) {
-        setDepressedKeys(addKey(depressedKeys, ev.code));
-      } else {
-        setDepressedKeys(deleteKey(depressedKeys, ev.code));
+      if (/Mac/.test(navigator.userAgent)) {
+        const modifiers = modifierKeys.current.filter((key) =>
+          ev.getModifierState(key),
+        );
+        if (modifiers.includes(ev.code)) {
+          setDepressedKeys(addKey(depressedKeys, ev.code));
+        } else {
+          setDepressedKeys(deleteKey(depressedKeys, ev.code));
+        }
       }
     } else {
       setDepressedKeys(addKey(depressedKeys, ev.code));
     }
   });
   useWindowEvent("keyup", (ev) => {
-    setDepressedKeys(deleteKey(depressedKeys, ev.code));
+    if (modifierKeys.current.includes(ev.code)) {
+      if (/Linux|Windows/.test(navigator.userAgent)) {
+        setDepressedKeys((depressedKeys) => {
+          if (depressedKeys.includes(ev.code)) {
+            return deleteKey(depressedKeys, ev.code);
+          } else {
+            return addKey(depressedKeys, ev.code);
+          }
+        });
+      } else if (/Mac/.test(navigator.userAgent)) {
+        setDepressedKeys(deleteKey(depressedKeys, ev.code));
+      }
+    } else {
+      setDepressedKeys(deleteKey(depressedKeys, ev.code));
+    }
   });
   return depressedKeys;
 }


### PR DESCRIPTION
## Progress Report

I've implemented this feature and tested it in Safari, Chrome, Firefox on macOS. The modifier key CapsLock works well. However NumLock cannot be treat as a modifier like CapsLock in my laptop. I checked the key in *Keyboard Event Viewer* you recommend in a windows computer, it appears reasonable as the [document](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState#modifier_keys_on_firefox) says. So I infer NumLock works fine in windows.

## Implementation

The Keydown event handler in practice page and the `useDepressedKeys` hook in setting page were changed.

Browsers can read modifier key state from OS only by getting a querying function `getModifierState` from `KeyboardEvent`.

In practice page Presenter related logic, I see some code transfer an original `KeyboardEvent` to a custom `KeyEvent` which return a new object contains some basic type properties. I needs call the `getModifierState` from original event, so I just assertion the type and use `defineProperty` to write a readonly object in some cases when updating properties is required.

### Something Compromise

Besides emulating a keyboard event, there is no reasonable approach to **get initial modifier keys state when page loaded or component mounted**. I believe emulating is a hacking way which may affect the user's practice course. So this PR cannot sync OS modifier keys state when page load, but when user press a specific modifier key, its state will be sync.

Also I didn't update states of all modifier keys by pressing any one of them, just the state of the pressed key will be sync. For fully update, it needs a few changes.

### Something Should Be Updated

I declared the modifier keys constant in two places, maybe it is wisely to define such a property to a key when the `loadKeyboard` and `makeKeys` function called? If it is, I could get keyboard keys from the context.