### PR TITLE
keyboard color consistency

### DIFF
--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -303,7 +303,7 @@ function NormalLayout({
           depressedKeys={depressedKeys}
           toggledKeys={toggledKeys}
           lastLesson={state.lastLesson}
-          showColors={settings.get(keyboardProps.colors) || !focus}
+          showColors={settings.get(keyboardProps.colors)}
         />
       </div>
       <Announcer state={state} />


### PR DESCRIPTION
When disabling the new feature of "Colored keys", when typing practice isn't focused, the setting is ignored.
This should fix it.