### PR TITLE
use UTC time to prevent problems with time zones

### DIFF
--- a/packages/keybr-result/lib/localdate.test.ts
+++ b/packages/keybr-result/lib/localdate.test.ts
@@ -21,6 +21,14 @@ test("create from timestamp", (t) => {
   t.is(String(new LocalDate(Date.parse("2001-02-03T04:05:06Z"))), "2001-02-03");
 });
 
+test("set hour to 00:00:00", (t) => {
+  let d1 = new LocalDate(Date.parse("1970-01-01T11:22:33Z"));
+  let d2 = new LocalDate(Date.parse("2001-02-03T04:05:06Z"));
+
+  t.is(d1.valueOf() % 86400000, 0);
+  t.is(d2.valueOf() % 86400000, 0);
+});
+
 test("create from date components", (t) => {
   t.is(String(new LocalDate(1970, 1, 1)), "1970-01-01");
   t.is(String(new LocalDate(2001, 2, 3)), "2001-02-03");

--- a/packages/keybr-result/lib/localdate.ts
+++ b/packages/keybr-result/lib/localdate.ts
@@ -103,14 +103,14 @@ export class LocalDate {
     } else {
       throw new TypeError();
     }
-    date.setHours(0);
-    date.setMinutes(0);
-    date.setSeconds(0);
-    date.setMilliseconds(0);
-    this.year = date.getFullYear();
-    this.month = date.getMonth() + 1;
-    this.dayOfMonth = date.getDate();
-    let dayOfWeek = date.getDay();
+    date.setUTCHours(0);
+    date.setUTCMinutes(0);
+    date.setUTCSeconds(0);
+    date.setUTCMilliseconds(0);
+    this.year = date.getUTCFullYear();
+    this.month = date.getUTCMonth() + 1;
+    this.dayOfMonth = date.getUTCDate();
+    let dayOfWeek = date.getUTCDay();
     if (dayOfWeek === 0) {
       dayOfWeek = 7;
     }


### PR DESCRIPTION
I was having some problems with time zone in tests from keybr-result package. I think this would solve the issue related to #201 as well