### PR TITLE
Bump GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           cache: "npm"


### PR DESCRIPTION
Old ones based on Node 16 are deprecated.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20