### PR TITLE
Don't switch back to previous keys until the freshest key has reached target confidence

### DIFF
--- a/packages/keybr-lesson/lib/guided.ts
+++ b/packages/keybr-lesson/lib/guided.ts
@@ -90,16 +90,25 @@ export class GuidedLesson extends Lesson {
       }
     }
 
-    // Find the least confident of all included keys and focus on it.
     const confidenceOf = (key: LessonKey): number => {
       return recoverKeys ? key.confidence ?? 0 : key.bestConfidence ?? 0;
     };
-    const weakestKeys = lessonKeys
-      .findIncludedKeys()
-      .filter((key) => confidenceOf(key) < 1)
-      .sort((a, b) => confidenceOf(a) - confidenceOf(b));
-    if (weakestKeys.length > 0) {
-      lessonKeys.focus(weakestKeys[0].letter);
+
+    const includedKeys = lessonKeys.findIncludedKeys();
+
+    // If a new key was recently unlocked, and has not reached the confidence
+    // level, continue focusing on this key.
+    const lastUnlockedKey = includedKeys[includedKeys.length - 1];
+    if (confidenceOf(lastUnlockedKey) < 1) {
+      lessonKeys.focus(lastUnlockedKey.letter);
+    } else {
+      // Else find the least confident of all included keys and focus on it.
+      const weakestKeys = includedKeys
+        .filter((key) => confidenceOf(key) < 1)
+        .sort((a, b) => confidenceOf(a) - confidenceOf(b));
+      if (weakestKeys.length > 0) {
+        lessonKeys.focus(weakestKeys[0].letter);
+      }
     }
 
     return lessonKeys;


### PR DESCRIPTION
### User story
If i have a number of keys already unlocked, lets call them `A B C D E`,
and I have reached `bestConfidence` or `confidence` for all, a new letter will be unlocked: `F`.
When I start  practicing with `F`, but  my general error rate maybe goes up massively.
Right now that will mean that I am thrown back to training old keys, even though I never trained `F` enough to actually master it. So I get in a ping pong of `F -> A -> F -> A` and it makes it harder to actually learn the new key, because i get distracted with old lessons frequently.

### Fix
With this PR, we only use the logic that pics the weakest keys of the included set, if the last key that was added passes the necessary confidence interval. 

This fixes #87