### PR TITLE
feat: add python source code syntax

### DIFF
--- a/packages/keybr-code/lib/README.md
+++ b/packages/keybr-code/lib/README.md
@@ -1,0 +1,16 @@
+# Adding a New Syntax
+
+## Defining the Grammar
+Create a file `syntax/lang_*.g` and define the grammar. See existing files for examples.
+
+## Registering
+Extend `syntax.ts` to include the new syntax.
+
+## Compiling
+Run `./compile.ts` to generate the corresponding TS files.
+
+Note: The output does not follow the linting rules, but this is not a problem since it will be automatically formatted on commit.
+
+## Sanity Check
+Run `./example.ts` to sanity check the grammar.
+

--- a/packages/keybr-code/lib/syntax.ts
+++ b/packages/keybr-code/lib/syntax.ts
@@ -6,6 +6,7 @@ import { Output } from "./output.ts";
 import lang_cpp from "./syntax/lang_cpp.ts";
 import lang_html_css from "./syntax/lang_html_css.ts";
 import lang_javascript from "./syntax/lang_javascript.ts";
+import lang_python from "./syntax/lang_python.ts";
 import lang_regex from "./syntax/lang_regex.ts";
 import lang_rust from "./syntax/lang_rust.ts";
 import lang_shell from "./syntax/lang_shell.ts";
@@ -60,6 +61,11 @@ export class Syntax implements EnumItem {
     "Shell",
     lang_shell,
   );
+  static readonly PYTHON = new Syntax(
+    "python", //
+    "Python",
+    lang_python,
+  );
   static readonly ALL = new Enum<Syntax>(
     Syntax.HTML,
     Syntax.CSS,
@@ -69,6 +75,7 @@ export class Syntax implements EnumItem {
     Syntax.JAVASCRIPT_EXP,
     Syntax.REGEX,
     Syntax.SHELL,
+    Syntax.PYTHON,
   );
 
   private constructor(

--- a/packages/keybr-code/lib/syntax/lang_javascript.g
+++ b/packages/keybr-code/lib/syntax/lang_javascript.g
@@ -10,7 +10,7 @@ js_primary_exp ->
   | js_call_exp
   ;
 
-js_array_literal -> "[" js_primary_exp [ "," _ js_primary_exp ] "]";
+js_array_literal -> "[" js_primary_exp [ "," _ js_primary_exp ] "]" ;
 
 js_object_literal -> "{" _ js_property_name ":" _ js_property_value _ "}" ;
 

--- a/packages/keybr-code/lib/syntax/lang_python.g
+++ b/packages/keybr-code/lib/syntax/lang_python.g
@@ -1,0 +1,336 @@
+start -> python_statement ;
+
+python_statement ->
+    python_function_definition
+  | python_class_definition
+  | python_assign
+  | python_return
+  | python_comment
+  ;
+
+python_function_definition -> "def" _ python_function_name "(" python_arguments ")" [ _ "->" _ python_type ] ":";
+
+python_class_definition -> "class" _ python_class_name [ "(" python_class_name ")" ] ":" ;
+
+python_assign -> python_variable_name [ "[" python_literal "]" ] _ "=" _ python_expression ;
+
+python_return -> "return" _ python_expression ;
+
+python_arguments -> python_argument [ "," _ python_argument ] ;
+
+python_argument -> python_variable_name [ ":" _ python_type ] ;
+
+python_expression ->
+    python_literal
+  | python_unary_operation
+  | python_binary_operation
+  | ( "(" python_expression ")" )
+  | python_list_definition
+  | python_dict_definition
+  | python_function_call
+  ;
+
+python_unary_operation ->
+    ( python_expression _ "is" _ [ "not" _ ] "None" )
+  | ( "not" _ python_expression )
+  | ( "~" python_expression )
+  ;
+
+python_binary_operation -> python_expression _ python_binary_operator _ python_expression ;
+
+python_function_call -> python_function_name "(" python_function_arg [ "," _ python_function_arg ] ;
+
+python_function_arg -> python_variable_name "=" python_expression ;
+
+python_type ->
+    python_primitive_type
+  | ( "list[" python_primitive_type "]" )
+  | ( "dict[" python_primitive_type "," _ python_primitive_type "]" )
+  | ( "tuple[" python_primitive_type "," _ "...]" )
+  | ( python_primitive_type _ "|" _ python_primitive_type )
+  ;
+
+python_primitive_type ->
+    python_class_name
+  | "int"
+  | "str"
+  | "bool"
+  | "float"
+  | "None"
+  ;
+
+python_binary_operator ->
+    "+"
+  | "-"
+  | "*"
+  | "/"
+  | "//"
+  | "%"
+  | "**"
+  | "@"
+  | "&"
+  | "|"
+  | ">"
+  | "<"
+  | ">="
+  | "<="
+  | "=="
+  | "in"
+  | ("not" _ "in")
+  | "^"
+  ;
+
+python_list_definition -> "[" python_expression [ "," _ python_expression ] "]" ;
+
+python_dict_definition -> "{" python_dict_key_value_pair [ "," _ python_dict_key_value_pair ] "}" ;
+
+python_dict_key_value_pair -> python_literal ":" _ python_expression ;
+
+python_literal -> python_string_literal | python_number_literal ;
+
+python_string_literal ->
+    ("\"" python_string_value "\"")
+  | ("'" python_string_value "'" )
+  | ("\"\"\"" python_string_value "\"\"\"")
+  | ("'''" python_string_value "'''" )
+  ;
+
+python_variable_name ->
+    "i"
+  | "x"
+  | "_"
+  | "y"
+  | "v"
+  | "result"
+  | "out"
+  | "config"
+  | "inputs"
+  | "k"
+  | "output"
+  | "batch_size"
+  | "__all__"
+  | "value"
+  | "n"
+  | "j"
+  | "expected"
+  | "data"
+  | "outputs"
+  | "dtype"
+  | "s"
+  | "b"
+  | "a"
+  | "key"
+  | "res"
+  | "name"
+  | "op"
+  | "width"
+  | "img"
+  | "mask"
+  | "height"
+  | "B"
+  | "shape"
+  | "f"
+  | "c"
+  | "df"
+  | "h"
+  | "m"
+  | "w"
+  | "t"
+  | "index"
+  | "values"
+  | "d"
+  | "H"
+  | "input_shape"
+  | "root"
+  | "count"
+  | "actual"
+  | "W"
+  | "C"
+  ;
+
+python_function_name ->
+    "__init__"
+  | "call"
+  | "get_config"
+  | "__repr__"
+  | "main"
+  | "build"
+  | "__call__"
+  | "from_config"
+  | "__getitem__"
+  | "__len__"
+  | "get"
+  | "__iter__"
+  | "dfs"
+  | "run"
+  | "__str__"
+  | "__eq__"
+  | "add"
+  | "test_correctness"
+  | "update"
+  | "create"
+  | "append"
+  | "__enter__"
+  | "__exit__"
+  | "load"
+  | "__getattr__"
+  | "pop"
+  | "constants"
+  | "wrapper"
+  | "__setitem__"
+  | "insert"
+  | "reverse"
+  | "preprocess_input"
+  | "__ne__"
+  | "__new__"
+  | "shape"
+  | "remove"
+  | "find"
+  | "identity"
+  | "serialize"
+  | "size"
+  | "copy"
+  | "floor"
+  | "reset_state"
+  | "func"
+  | "inverse_transform"
+  | "configure"
+  | "save"
+  | "update_state"
+  | "dtype"
+  | "inverse"
+  ;
+
+python_class_name ->
+    "Node"
+  | "Graph"
+  | "TestSuite"
+  | "MyModel"
+  | "Create"
+  | "Cols"
+  | "Rows"
+  | "MyDense"
+  | "Attention"
+  | "Load"
+  | "Save"
+  | "TreeNode"
+  | "Dog"
+  | "Cat"
+  | "JDBC"
+  | "Constants"
+  | "Model"
+  | "Variable"
+  | "CustomModel"
+  | "ActivityRegularizationLayer"
+  ;
+
+python_string_value ->
+    ""
+  | "."
+  | "__main__"
+  | "float32"
+  | ")"
+  | "channels_last"
+  | "*"
+  | "int32"
+  | "tensorflow"
+  | ", "
+  | "1"
+  | "name"
+  | "B"
+  | "int"
+  | "torch"
+  | "a"
+  | "valid"
+  | "zeros"
+  | "dtype"
+  | "channels_first"
+  | "2"
+  | "x"
+  | "/"
+  | "same"
+  | "constant"
+  | "int64"
+  | "_"
+  | "jax"
+  | "shape"
+  | "0"
+  | "^[a-z][a-z0-9_]*$"
+  | "^[0-9]+$"
+  | "^[A-Z]+$"
+  | "^([0-9a-f]+) (.*)$"
+  | ";"
+  | "\\n"
+  | "\\t"
+  | "\\r\\n"
+  | "C:\\\\"
+  ;
+
+python_number_literal ->
+    "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "10"
+  | "6"
+  | "8"
+  | "0.5"
+  | "7"
+  | "9"
+  | "100"
+  | "32"
+  | "16"
+  | "20"
+  | "0.1"
+  | "12"
+  | "0.001"
+  | "0.2"
+  | "15"
+  | "11"
+  | "64"
+  | "0.0001"
+  | "0.01"
+  | "128"
+  | "256"
+  | "1000"
+  | "0.3"
+  | "24"
+  | "30"
+  | "13"
+  | "0.9"
+  | "50.0"
+  | "0.8"
+  | "255"
+  | "14"
+  | "0.25"
+  | "1e-06"
+  | "0.4"
+  | "512"
+  | "1024"
+  | "40"
+  | "1.5"
+  | "17"
+  | "25"
+  | "0.7"
+  | "200"
+  | "10000"
+  | "60"
+  | "1e-05"
+  ;
+
+python_comment ->
+    "# type: ignore"
+  | "# TODO: fix!"
+  | "# TODO: fix?"
+  | "# ?"
+  | "# !"
+  | "#!/usr/bin/env python"
+  | "# noqa"
+  | "# -*- coding: utf-8 -*-"
+  | "# TODO: implement"
+  | "# ``H x W``"
+  | "# `1 x 1`"
+  | "# ;"
+  ;
+

--- a/packages/keybr-code/lib/syntax/lang_python.ts
+++ b/packages/keybr-code/lib/syntax/lang_python.ts
@@ -1,0 +1,682 @@
+// Generated file, do not edit.
+
+import { type Rules } from "../ast.ts";
+
+export default {
+  start: {
+    ref: "python_statement",
+  },
+  python_statement: {
+    alt: [
+      {
+        ref: "python_function_definition",
+      },
+      {
+        ref: "python_class_definition",
+      },
+      {
+        ref: "python_assign",
+      },
+      {
+        ref: "python_return",
+      },
+      {
+        ref: "python_comment",
+      },
+    ],
+  },
+  python_function_definition: {
+    seq: [
+      "def ",
+      {
+        ref: "python_function_name",
+      },
+      "(",
+      {
+        ref: "python_arguments",
+      },
+      ")",
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            " -> ",
+            {
+              ref: "python_type",
+            },
+          ],
+        },
+      },
+      ":",
+    ],
+  },
+  python_class_definition: {
+    seq: [
+      "class ",
+      {
+        ref: "python_class_name",
+      },
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            "(",
+            {
+              ref: "python_class_name",
+            },
+            ")",
+          ],
+        },
+      },
+      ":",
+    ],
+  },
+  python_assign: {
+    seq: [
+      {
+        ref: "python_variable_name",
+      },
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            "[",
+            {
+              ref: "python_literal",
+            },
+            "]",
+          ],
+        },
+      },
+      " = ",
+      {
+        ref: "python_expression",
+      },
+    ],
+  },
+  python_return: {
+    seq: [
+      "return ",
+      {
+        ref: "python_expression",
+      },
+    ],
+  },
+  python_arguments: {
+    seq: [
+      {
+        ref: "python_argument",
+      },
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            ", ",
+            {
+              ref: "python_argument",
+            },
+          ],
+        },
+      },
+    ],
+  },
+  python_argument: {
+    seq: [
+      {
+        ref: "python_variable_name",
+      },
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            ": ",
+            {
+              ref: "python_type",
+            },
+          ],
+        },
+      },
+    ],
+  },
+  python_expression: {
+    alt: [
+      {
+        ref: "python_literal",
+      },
+      {
+        ref: "python_unary_operation",
+      },
+      {
+        ref: "python_binary_operation",
+      },
+      {
+        seq: [
+          "(",
+          {
+            ref: "python_expression",
+          },
+          ")",
+        ],
+      },
+      {
+        ref: "python_list_definition",
+      },
+      {
+        ref: "python_dict_definition",
+      },
+      {
+        ref: "python_function_call",
+      },
+    ],
+  },
+  python_unary_operation: {
+    alt: [
+      {
+        seq: [
+          {
+            ref: "python_expression",
+          },
+          " is ",
+          {
+            f: 0.5,
+            opt: "not ",
+          },
+          "None",
+        ],
+      },
+      {
+        seq: [
+          "not ",
+          {
+            ref: "python_expression",
+          },
+        ],
+      },
+      {
+        seq: [
+          "~",
+          {
+            ref: "python_expression",
+          },
+        ],
+      },
+    ],
+  },
+  python_binary_operation: {
+    seq: [
+      {
+        ref: "python_expression",
+      },
+      " ",
+      {
+        ref: "python_binary_operator",
+      },
+      " ",
+      {
+        ref: "python_expression",
+      },
+    ],
+  },
+  python_function_call: {
+    seq: [
+      {
+        ref: "python_function_name",
+      },
+      "(",
+      {
+        ref: "python_function_arg",
+      },
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            ", ",
+            {
+              ref: "python_function_arg",
+            },
+          ],
+        },
+      },
+    ],
+  },
+  python_function_arg: {
+    seq: [
+      {
+        ref: "python_variable_name",
+      },
+      "=",
+      {
+        ref: "python_expression",
+      },
+    ],
+  },
+  python_type: {
+    alt: [
+      {
+        ref: "python_primitive_type",
+      },
+      {
+        seq: [
+          "list[",
+          {
+            ref: "python_primitive_type",
+          },
+          "]",
+        ],
+      },
+      {
+        seq: [
+          "dict[",
+          {
+            ref: "python_primitive_type",
+          },
+          ", ",
+          {
+            ref: "python_primitive_type",
+          },
+          "]",
+        ],
+      },
+      {
+        seq: [
+          "tuple[",
+          {
+            ref: "python_primitive_type",
+          },
+          ", ...]",
+        ],
+      },
+      {
+        seq: [
+          {
+            ref: "python_primitive_type",
+          },
+          " | ",
+          {
+            ref: "python_primitive_type",
+          },
+        ],
+      },
+    ],
+  },
+  python_primitive_type: {
+    alt: [
+      {
+        ref: "python_class_name",
+      },
+      "int",
+      "str",
+      "bool",
+      "float",
+      "None",
+    ],
+  },
+  python_binary_operator: {
+    alt: [
+      "+",
+      "-",
+      "*",
+      "/",
+      "//",
+      "%",
+      "**",
+      "@",
+      "&",
+      "|",
+      ">",
+      "<",
+      ">=",
+      "<=",
+      "==",
+      "in",
+      "not in",
+      "^",
+    ],
+  },
+  python_list_definition: {
+    seq: [
+      "[",
+      {
+        ref: "python_expression",
+      },
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            ", ",
+            {
+              ref: "python_expression",
+            },
+          ],
+        },
+      },
+      "]",
+    ],
+  },
+  python_dict_definition: {
+    seq: [
+      "{",
+      {
+        ref: "python_dict_key_value_pair",
+      },
+      {
+        f: 0.5,
+        opt: {
+          seq: [
+            ", ",
+            {
+              ref: "python_dict_key_value_pair",
+            },
+          ],
+        },
+      },
+      "}",
+    ],
+  },
+  python_dict_key_value_pair: {
+    seq: [
+      {
+        ref: "python_literal",
+      },
+      ": ",
+      {
+        ref: "python_expression",
+      },
+    ],
+  },
+  python_literal: {
+    alt: [
+      {
+        ref: "python_string_literal",
+      },
+      {
+        ref: "python_number_literal",
+      },
+    ],
+  },
+  python_string_literal: {
+    alt: [
+      {
+        seq: [
+          '"',
+          {
+            ref: "python_string_value",
+          },
+          '"',
+        ],
+      },
+      {
+        seq: [
+          "'",
+          {
+            ref: "python_string_value",
+          },
+          "'",
+        ],
+      },
+      {
+        seq: [
+          '"""',
+          {
+            ref: "python_string_value",
+          },
+          '"""',
+        ],
+      },
+      {
+        seq: [
+          "'''",
+          {
+            ref: "python_string_value",
+          },
+          "'''",
+        ],
+      },
+    ],
+  },
+  python_variable_name: {
+    alt: [
+      "i",
+      "x",
+      "_",
+      "y",
+      "v",
+      "result",
+      "out",
+      "config",
+      "inputs",
+      "k",
+      "output",
+      "batch_size",
+      "__all__",
+      "value",
+      "n",
+      "j",
+      "expected",
+      "data",
+      "outputs",
+      "dtype",
+      "s",
+      "b",
+      "a",
+      "key",
+      "res",
+      "name",
+      "op",
+      "width",
+      "img",
+      "mask",
+      "height",
+      "B",
+      "shape",
+      "f",
+      "c",
+      "df",
+      "h",
+      "m",
+      "w",
+      "t",
+      "index",
+      "values",
+      "d",
+      "H",
+      "input_shape",
+      "root",
+      "count",
+      "actual",
+      "W",
+      "C",
+    ],
+  },
+  python_function_name: {
+    alt: [
+      "__init__",
+      "call",
+      "get_config",
+      "__repr__",
+      "main",
+      "build",
+      "__call__",
+      "from_config",
+      "__getitem__",
+      "__len__",
+      "get",
+      "__iter__",
+      "dfs",
+      "run",
+      "__str__",
+      "__eq__",
+      "add",
+      "test_correctness",
+      "update",
+      "create",
+      "append",
+      "__enter__",
+      "__exit__",
+      "load",
+      "__getattr__",
+      "pop",
+      "constants",
+      "wrapper",
+      "__setitem__",
+      "insert",
+      "reverse",
+      "preprocess_input",
+      "__ne__",
+      "__new__",
+      "shape",
+      "remove",
+      "find",
+      "identity",
+      "serialize",
+      "size",
+      "copy",
+      "floor",
+      "reset_state",
+      "func",
+      "inverse_transform",
+      "configure",
+      "save",
+      "update_state",
+      "dtype",
+      "inverse",
+    ],
+  },
+  python_class_name: {
+    alt: [
+      "Node",
+      "Graph",
+      "TestSuite",
+      "MyModel",
+      "Create",
+      "Cols",
+      "Rows",
+      "MyDense",
+      "Attention",
+      "Load",
+      "Save",
+      "TreeNode",
+      "Dog",
+      "Cat",
+      "JDBC",
+      "Constants",
+      "Model",
+      "Variable",
+      "CustomModel",
+      "ActivityRegularizationLayer",
+    ],
+  },
+  python_string_value: {
+    alt: [
+      "",
+      ".",
+      "__main__",
+      "float32",
+      ")",
+      "channels_last",
+      "*",
+      "int32",
+      "tensorflow",
+      ", ",
+      "1",
+      "name",
+      "B",
+      "int",
+      "torch",
+      "a",
+      "valid",
+      "zeros",
+      "dtype",
+      "channels_first",
+      "2",
+      "x",
+      "/",
+      "same",
+      "constant",
+      "int64",
+      "_",
+      "jax",
+      "shape",
+      "0",
+      "^[a-z][a-z0-9_]*$",
+      "^[0-9]+$",
+      "^[A-Z]+$",
+      "^([0-9a-f]+) (.*)$",
+      ";",
+      "\\n",
+      "\\t",
+      "\\r\\n",
+      "C:\\\\",
+    ],
+  },
+  python_number_literal: {
+    alt: [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "10",
+      "6",
+      "8",
+      "0.5",
+      "7",
+      "9",
+      "100",
+      "32",
+      "16",
+      "20",
+      "0.1",
+      "12",
+      "0.001",
+      "0.2",
+      "15",
+      "11",
+      "64",
+      "0.0001",
+      "0.01",
+      "128",
+      "256",
+      "1000",
+      "0.3",
+      "24",
+      "30",
+      "13",
+      "0.9",
+      "50.0",
+      "0.8",
+      "255",
+      "14",
+      "0.25",
+      "1e-06",
+      "0.4",
+      "512",
+      "1024",
+      "40",
+      "1.5",
+      "17",
+      "25",
+      "0.7",
+      "200",
+      "10000",
+      "60",
+      "1e-05",
+    ],
+  },
+  python_comment: {
+    alt: [
+      "# type: ignore",
+      "# TODO: fix!",
+      "# TODO: fix?",
+      "# ?",
+      "# !",
+      "#!/usr/bin/env python",
+      "# noqa",
+      "# -*- coding: utf-8 -*-",
+      "# TODO: implement",
+      "# ``H x W``",
+      "# `1 x 1`",
+      "# ;",
+    ],
+  },
+} as Rules;


### PR DESCRIPTION
## Overview
This PR adds a Python option to the "Source Code" Syntax dropdown.

Output of `example.ts`:
```
=== Python ===
class Attention: return (inverse(result=(insert(img={0.01: serialize(key=({"""*""": (256), 'C:\\': ~reverse(B=60})})) # ``H x W`` class JDBC(Node): def __len__(out, y): # ; inputs = 'int'
class TestSuite(Rows): class MyModel: class Rows: # ? def update_state(count) -> int | None: def remove(name) -> bool | str: # noqa key["""C:\\"""] = 200 class Variable(Create):
# ``H x W`` def pop(img: list[float]): i[255] = [{"tensorflow": ({512: """, """, 9: [(shape(n=[__repr__(j=['''int''', (512)], expected=~__new__(output=(not (__setitem__(f="""valid""")), [0.01, (
return {200: __eq__(_="\r\n" is None, 1024: [{"""int32""": [add(input_shape=0.4, height=~{"jax": {32: [dtype(_=[from_config(n=({'''channels_first''': [__call__(value=not wrapper(input_shape=0.01 is
return identity(k="""torch""", H=[1e-05] #!/usr/bin/env python # ? d['''int'''] = {1e-05: [inverse_transform(shape={", ": ([60, {'\n': [{1000: ''';'''}]}])} is None, i=remove(op=~([(({17: [not (
```

Also, I have included a small readme on how to add a new syntax. (The process is quite simple, but it was a bit tricky without instructions.)

## Details
The grammar does not cover the full language but tries to cover the most basic elements:
- Function definitions
- Class definitions
- Assign and return statements
- Expressions including
  - Literals
  - Unary operators
  - Binary operators
  - Function calls
  - List definitions
  - Dict definitions
- Type hints
- Comments

I have included all the symbols at least twice.

For the variable, function, and class names, as well as the constants, I have used commonly occurring values from a few popular repositories.