### PR TITLE
Fix characters not registering correctly

### DIFF
--- a/packages/keybr-keyboard/lib/filter.ts
+++ b/packages/keybr-keyboard/lib/filter.ts
@@ -696,5 +696,6 @@ export function filterText(text: string, set: CodePointSet): string {
 filterText.normalize = normalize;
 
 function normalize(codePoint: CodePoint): CodePoint {
+  return codePoint;
   return basicPunctuation.get(codePoint) ?? codePoint;
 }


### PR DESCRIPTION
Return codePoint instead of the normalize codePoint, so the languages that uses that characters can type normally