### PR TITLE
feat: Move the 'Caps lock is on' dialog below the text

### DIFF
--- a/packages/keybr-textinput-ui/lib/TextArea.module.less
+++ b/packages/keybr-textinput-ui/lib/TextArea.module.less
@@ -23,3 +23,9 @@
   background-color: var(--Popup__background-color);
   box-shadow: var(--Popup--small__box-shadow);
 }
+
+.capsLockMessageArea {
+  position: relative;
+  padding: 5px 10px;
+  font-weight: bold;
+}

--- a/packages/keybr-textinput-ui/lib/TextArea.tsx
+++ b/packages/keybr-textinput-ui/lib/TextArea.tsx
@@ -115,7 +115,7 @@ export function TextArea({
         focus={demo || focus}
       />
       {!demo && focus && ModifierState.capsLock && (
-        <div className={styles.messageArea}>
+        <div className={styles.capsLockMessageArea}>
           <div className={styles.messageText}>
             <FormattedMessage
               id="textArea.capsLock.message"


### PR DESCRIPTION
### Summary
This pull request addresses **Issue #343**, where the "Caps Lock is on" dialogue occludes the text being typed, potentially disrupting the user experience. The updated solution ensures that users can focus on the text even if Caps Lock is accidentally engaged.

### Changes Made
- Moved the "Caps Lock is on" dialogue below the text input area.
- Adjusted the layout so the text lines box expands dynamically, ensuring the keyboard SVG shifts down without overlapping critical UI elements.
- Maintains user focus by drawing attention to Caps Lock status without blocking the text.

### Screenshots
**Before:**
![Before](https://github.com/user-attachments/assets/dd86e632-0700-4ed0-a50d-f608310067b1)

**After:**
![After](https://github.com/user-attachments/assets/9dadea1f-7d86-46b3-8818-fbb555b99986)

### Benefits
- The new placement ensures the dialogue is noticeable while preserving text visibility.
- A non-intrusive design improves the user experience by avoiding overlap with the text input area.

### Feedback
This is my first contribution to an open-source project! I'm open to suggestions or alternative ideas for improving this solution. Looking forward to your feedback.
