### PR TITLE
feat: add ThumbCluster keycodes and update layout configurations. Thi…

### DIFF
--- a/packages/keybr-keyboard-io/lib/keys.ts
+++ b/packages/keybr-keyboard-io/lib/keys.ts
@@ -63,4 +63,9 @@ export const characterKeys: readonly KeyId[] = [
   "IntlRo",
   // ---
   "Space",
+  // --- Those are virtual keys mapped to physical keys by keyboard firmware.
+  "ThumbClusterLeft1",
+  "ThumbClusterLeft2",
+  "ThumbClusterRight1",
+  "ThumbClusterRight2",
 ];

--- a/packages/keybr-keyboard/lib/geometry/matrix.ts
+++ b/packages/keybr-keyboard/lib/geometry/matrix.ts
@@ -266,4 +266,24 @@ export const MATRIX: GeometryDict = {
     labels: [{ text: "Shift" }],
     zones: ["pinky", "right", "bottom"],
   },
+  ThumbClusterLeft1: {
+    x: 4.5,
+    y: 4,
+    zones: ["thumb", "left", "bottom"],
+  },
+  ThumbClusterLeft2: {
+    x: 5.5,
+    y: 4,
+    zones: ["thumb", "left", "bottom"],
+  },
+  ThumbClusterRight1: {
+    x: 7.5,
+    y: 4,
+    zones: ["thumb", "right", "bottom"],
+  },
+  ThumbClusterRight2: {
+    x: 8.5,
+    y: 4,
+    zones: ["thumb", "right", "bottom"],
+  },
 };

--- a/packages/keybr-keyboard/lib/keycode.ts
+++ b/packages/keybr-keyboard/lib/keycode.ts
@@ -262,4 +262,8 @@ export enum KeyCode {
   ScrollLock,
   /** Pause and Break */
   Pause,
+  ThumbClusterLeft1,
+  ThumbClusterLeft2,
+  ThumbClusterRight1,
+  ThumbClusterRight2,
 }

--- a/packages/keybr-keyboard/lib/layout.ts
+++ b/packages/keybr-keyboard/lib/layout.ts
@@ -1067,7 +1067,7 @@ export class Layout implements XEnumItem {
     /* name= */ "Hands Down Promethium (Matrix)",
     /* family= */ "en-hands-down-promethium",
     /* language= */ Language.EN,
-    /* emulate= */ true,
+    /* emulate= */ false,
     /* geometries= */ new Enum(Geometry.MATRIX),
   );
 

--- a/packages/keybr-keyboard/lib/layout/en_hands_down_promethium.ts
+++ b/packages/keybr-keyboard/lib/layout/en_hands_down_promethium.ts
@@ -52,4 +52,6 @@ export const LAYOUT_EN_HANDS_DOWN_PROMETHIUM: CharacterDict = {
   Period: [/* EQUALS SIGN */ 0x003d, /* PLUS SIGN */ 0x002b],
   Slash: [/* SOLIDUS */ 0x002f, /* QUESTION MARK */ 0x003f],
   Space: [/* SPACE */ 0x0020],
+  ThumbClusterLeft1: [/* LATIN SMALL LETTER R */ 0x0072, /* LATIN CAPITAL LETTER R */ 0x0052],
+  ThumbClusterRight1: [/* SPACE */ 0x0020]
 };


### PR DESCRIPTION
Some of the new type of matrix layouts are using thumb cluster section to put there one or two letters.
Hands down promethium is such one
https://www.reddit.com/r/KeyboardLayouts/comments/1g66ivi/hands_down_promethium_snth_meets_hd_silverengram/
With current configuration letter R is not in the matrix layout and because of that is also excluded from lessons. 

PR adds two thumb buttons on each side that any of the matrix layouts can later use it. 
With letter in thumb cluster emulation does not make sense as there is no fifth row on standard keyboard.

With the change R is correctly added to lessons. 
Thanks - great tool 