### PR TITLE
fix: toast wrapper blocking mouse events;

### DIFF
--- a/packages/keybr-widget/lib/components/toast/Toaster.module.less
+++ b/packages/keybr-widget/lib/components/toast/Toaster.module.less
@@ -11,4 +11,9 @@
   margin-inline: auto auto;
   margin-block: auto 0;
   padding: 3rem;
+  pointer-events: none;
+}
+
+.toaster > * {
+  pointer-events: auto;
 }


### PR DESCRIPTION
I was trying to change graph view in the profile page and could not click the toggles between display modes. The toast wrapper was eating my mouse events when the toggles were near the bottom of the page.