### PR TITLE
docs: add more info to getting started

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,6 +2,22 @@
 
 This is a [nodejs](https://nodejs.org/) application, so proficiency with the node ecosystem is required.
 
+### Prerequisites
+
+**NodeJS v22 or v20 must be installed.**\
+You can get NodeJS v22 or v20 without impacting other Node installations using [Node Version Manager](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating) (`nvm`)
+<details>
+  <summary>
+  Get NodeJS v22 with nvm
+  </summary>
+
+  ```shell
+  nvm install 22 && nvm use 22
+  ```
+</details>
+
+### Install and setup
+
 Clone this repository:
 
 ```shell

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,3 +59,11 @@ npm start
 ```
 
 With the default config the application should be accessible at [http://localhost:3000/](http://localhost:3000/)
+
+While actively developing, you may want your changes to be automatically built and
+visible on page refresh.\
+Run the following command at the same time as `npm start` in another shell:
+
+```shell
+npm run watch
+```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,7 +21,7 @@ You can get NodeJS v22 or v20 without impacting other Node installations using [
 Clone this repository:
 
 ```shell
-git clone git@github.com:aradzie/keybr.com.git
+git clone https://github.com/aradzie/keybr.com.git
 cd keybr.com
 ```
 


### PR DESCRIPTION
I had a few minor road bumps while following the getting started guide. This pull request adds some more information that I believe may smooth them over for others.

Through my experimentation and the existing test suite, it seems both NodeJS 22 and 20 work equally well. I chose to recommend 22 as I am unsure which you prefer or target.

Cloning via SSH fails if the user does not have a keypair, using HTTPS avoids that case and I argue having a SSH keypair is not necessary for getting started.