### PR TITLE
feat: SpeedChart plot visibility toggle

### DIFF
--- a/packages/keybr-chart/lib/Marker.module.less
+++ b/packages/keybr-chart/lib/Marker.module.less
@@ -51,3 +51,7 @@
   composes: root;
   background-color: var(--Chart-hist-r__color);
 }
+
+.clickable {
+  cursor: pointer;
+}

--- a/packages/keybr-chart/lib/Marker.module.less
+++ b/packages/keybr-chart/lib/Marker.module.less
@@ -4,6 +4,7 @@
   inline-size: 1rem;
   block-size: 1rem;
   line-height: 1rem;
+  user-select: none;
 }
 
 .slow {

--- a/packages/keybr-chart/lib/Marker.tsx
+++ b/packages/keybr-chart/lib/Marker.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { type ReactNode } from "react";
 import * as styles from "./Marker.module.less";
 
@@ -12,9 +13,9 @@ type Props = {
     | "histogram-h"
     | "histogram-m"
     | "histogram-r";
-};
+} & React.HTMLAttributes<HTMLSpanElement>;
 
-export function Marker({ type }: Props): ReactNode {
+export function Marker({ type, ...props }: Props): ReactNode {
   let cn;
   switch (type) {
     case "slow":
@@ -45,5 +46,12 @@ export function Marker({ type }: Props): ReactNode {
       cn = styles.histogram_r;
       break;
   }
-  return <span className={cn}>{"\u00A0"}</span>;
+
+  const isClickable = typeof props.onClick !== "undefined";
+
+  return (
+    <span {...props} className={clsx(cn, isClickable && styles.clickable)}>
+      {"\u00A0"}
+    </span>
+  );
 }

--- a/packages/keybr-chart/lib/SpeedChart.test.tsx
+++ b/packages/keybr-chart/lib/SpeedChart.test.tsx
@@ -18,7 +18,6 @@ test("render empty", () => {
           smoothness={1}
           width="100px"
           height="100px"
-          plotsVisible={0b111}
         />
       </FakeSettingsContext>
     </FakeIntlProvider>,
@@ -38,7 +37,6 @@ test("render non-empty", () => {
           smoothness={1}
           width="100px"
           height="100px"
-          plotsVisible={0b111}
         />
       </FakeSettingsContext>
     </FakeIntlProvider>,

--- a/packages/keybr-chart/lib/SpeedChart.test.tsx
+++ b/packages/keybr-chart/lib/SpeedChart.test.tsx
@@ -18,6 +18,7 @@ test("render empty", () => {
           smoothness={1}
           width="100px"
           height="100px"
+          plotsVisible={0b111}
         />
       </FakeSettingsContext>
     </FakeIntlProvider>,
@@ -37,6 +38,7 @@ test("render non-empty", () => {
           smoothness={1}
           width="100px"
           height="100px"
+          plotsVisible={0b111}
         />
       </FakeSettingsContext>
     </FakeIntlProvider>,

--- a/packages/keybr-chart/lib/SpeedChart.tsx
+++ b/packages/keybr-chart/lib/SpeedChart.tsx
@@ -87,12 +87,10 @@ function usePaint(
 
   return (plotsVisible: number) => {
     return (box: Rect): ShapeList => {
-      const projComplexity = projection(box, rIndex, rComplexity);
-      const projAccuracy = projection(box, rIndex, rAccuracy);
-      const projSpeed = projection(box, rIndex, rSpeed);
-
       const plots: ShapeList[] = [];
+
       if ((plotsVisible & PLOT_MASK.complexity) !== 0) {
+        const projComplexity = projection(box, rIndex, rComplexity);
         plots.push(
           paintScatterPlot(projComplexity, vIndex, vComplexity, {
             style: styles.complexity,
@@ -100,6 +98,7 @@ function usePaint(
         );
       }
       if ((plotsVisible & PLOT_MASK.accuracy) !== 0) {
+        const projAccuracy = projection(box, rIndex, rAccuracy);
         plots.push(
           paintScatterPlot(projAccuracy, vIndex, vAccuracy, {
             style: styles.accuracy,
@@ -107,6 +106,7 @@ function usePaint(
         );
       }
       if ((plotsVisible & PLOT_MASK.speed) !== 0) {
+        const projSpeed = projection(box, rIndex, rSpeed);
         plots.push(
           paintScatterPlot(projSpeed, vIndex, vSpeed, {
             style: styles.speed,

--- a/packages/keybr-chart/lib/SpeedChart.tsx
+++ b/packages/keybr-chart/lib/SpeedChart.tsx
@@ -11,6 +11,7 @@ import { paintCurve, paintScatterPlot, projection } from "./graph.ts";
 import { type ChartStyles, useChartStyles } from "./use-chart-styles.ts";
 
 export const PLOT_MASK = {
+  all: 0b111,
   accuracy: 0b001,
   speed: 0b010,
   complexity: 0b100,
@@ -25,13 +26,14 @@ export function SpeedChart({
 }: {
   readonly results: readonly Result[];
   readonly smoothness: number;
-  readonly plotsVisible: number;
+  readonly plotsVisible?: number;
 } & SizeProps): ReactNode {
   const styles = useChartStyles();
   const paint = usePaint(styles, results, smoothness);
+  const resolvedPlotsVisible = plotsVisible ?? PLOT_MASK.all;
   const paintWithVisiblePlots = useMemo(() => {
-    return paint(plotsVisible);
-  }, [paint, plotsVisible]);
+    return paint(resolvedPlotsVisible);
+  }, [paint, resolvedPlotsVisible]);
   return (
     <Chart width={width} height={height}>
       <Canvas paint={chartArea(styles, paintWithVisiblePlots)} />

--- a/packages/keybr-chart/lib/SpeedChart.tsx
+++ b/packages/keybr-chart/lib/SpeedChart.tsx
@@ -12,10 +12,13 @@ import { type ChartStyles, useChartStyles } from "./use-chart-styles.ts";
 
 export const PLOT_MASK = {
   all: 0b111,
+  none: 0b000,
   accuracy: 0b001,
   speed: 0b010,
   complexity: 0b100,
 } as const;
+
+export type PlotMask = (typeof PLOT_MASK)[keyof typeof PLOT_MASK];
 
 export function SpeedChart({
   results,
@@ -26,7 +29,7 @@ export function SpeedChart({
 }: {
   readonly results: readonly Result[];
   readonly smoothness: number;
-  readonly plotsVisible?: number;
+  readonly plotsVisible?: PlotMask;
 } & SizeProps): ReactNode {
   const styles = useChartStyles();
   const paint = usePaint(styles, results, smoothness);

--- a/packages/page-profile/lib/profile/SpeedChartSection.tsx
+++ b/packages/page-profile/lib/profile/SpeedChartSection.tsx
@@ -1,26 +1,39 @@
+import type { PlotMask } from "@keybr/chart";
 import { Marker, PLOT_MASK, SpeedChart } from "@keybr/chart";
 import { hasData } from "@keybr/math";
 import { type Result } from "@keybr/result";
 import { Explainer, Figure } from "@keybr/widget";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { ChartWrapper } from "./ChartWrapper.tsx";
 import { SmoothnessRange } from "./SmoothnessRange.tsx";
 
 export function SpeedChartSection({ results }: { results: readonly Result[] }) {
   const [smoothness, setSmoothness] = useState(0.5);
-  const [plotsVisible, setPlotsVisible] = useState(PLOT_MASK.all);
 
-  const toggleSpeedPlot = () => {
-    setPlotsVisible(plotsVisible ^ PLOT_MASK.speed);
+  const initialPlotsVisible = PLOT_MASK.all;
+
+  const [soloedPlots, setSoloedPlots] = useState(initialPlotsVisible);
+  const [toggledPlots, setToggledPlots] = useState(initialPlotsVisible);
+
+  const plotsVisible = useMemo(() => {
+    return soloedPlots & toggledPlots;
+  }, [toggledPlots, soloedPlots]);
+
+  const soloPlot = (plotMask: PlotMask) => {
+    return () => {
+      setSoloedPlots(plotMask);
+    };
   };
 
-  const toggleAccuracyPlot = () => {
-    setPlotsVisible(plotsVisible ^ PLOT_MASK.accuracy);
+  const togglePlot = (plotMask: PlotMask) => {
+    return () => {
+      setToggledPlots(toggledPlots ^ plotMask);
+    };
   };
 
-  const toggleComplexityPlot = () => {
-    setPlotsVisible(plotsVisible ^ PLOT_MASK.complexity);
+  const resetSoloedPlots = () => {
+    setSoloedPlots(initialPlotsVisible);
   };
 
   return (
@@ -62,9 +75,30 @@ export function SpeedChartSection({ results }: { results: readonly Result[] }) {
           id="profile.chart.speed.legend"
           defaultMessage="Horizontal axis: lesson number. Vertical axis: {label1} – typing speed, {label2} – typing accuracy, {label3} – number of keys in the lessons."
           values={{
-            label1: <Marker type="speed" onClick={toggleSpeedPlot} />,
-            label2: <Marker type="accuracy" onClick={toggleAccuracyPlot} />,
-            label3: <Marker type="complexity" onClick={toggleComplexityPlot} />,
+            label1: (
+              <Marker
+                type="speed"
+                onClick={togglePlot(PLOT_MASK.speed)}
+                onMouseEnter={soloPlot(PLOT_MASK.speed)}
+                onMouseLeave={resetSoloedPlots}
+              />
+            ),
+            label2: (
+              <Marker
+                type="accuracy"
+                onClick={togglePlot(PLOT_MASK.accuracy)}
+                onMouseEnter={soloPlot(PLOT_MASK.accuracy)}
+                onMouseLeave={resetSoloedPlots}
+              />
+            ),
+            label3: (
+              <Marker
+                type="complexity"
+                onClick={togglePlot(PLOT_MASK.complexity)}
+                onMouseEnter={soloPlot(PLOT_MASK.complexity)}
+                onMouseLeave={resetSoloedPlots}
+              />
+            ),
           }}
         />
       </Figure.Legend>

--- a/packages/page-profile/lib/profile/SpeedChartSection.tsx
+++ b/packages/page-profile/lib/profile/SpeedChartSection.tsx
@@ -62,21 +62,9 @@ export function SpeedChartSection({ results }: { results: readonly Result[] }) {
           id="profile.chart.speed.legend"
           defaultMessage="Horizontal axis: lesson number. Vertical axis: {label1} – typing speed, {label2} – typing accuracy, {label3} – number of keys in the lessons."
           values={{
-            label1: (
-              <span onClick={toggleSpeedPlot}>
-                <Marker type="speed" />
-              </span>
-            ),
-            label2: (
-              <span onClick={toggleAccuracyPlot}>
-                <Marker type="accuracy" />
-              </span>
-            ),
-            label3: (
-              <span onClick={toggleComplexityPlot}>
-                <Marker type="complexity" />
-              </span>
-            ),
+            label1: <Marker type="speed" onClick={toggleSpeedPlot} />,
+            label2: <Marker type="accuracy" onClick={toggleAccuracyPlot} />,
+            label3: <Marker type="complexity" onClick={toggleComplexityPlot} />,
           }}
         />
       </Figure.Legend>

--- a/packages/page-profile/lib/profile/SpeedChartSection.tsx
+++ b/packages/page-profile/lib/profile/SpeedChartSection.tsx
@@ -1,4 +1,4 @@
-import { Marker, SpeedChart } from "@keybr/chart";
+import { Marker, PLOT_MASK, SpeedChart } from "@keybr/chart";
 import { hasData } from "@keybr/math";
 import { type Result } from "@keybr/result";
 import { Explainer, Figure } from "@keybr/widget";
@@ -9,6 +9,19 @@ import { SmoothnessRange } from "./SmoothnessRange.tsx";
 
 export function SpeedChartSection({ results }: { results: readonly Result[] }) {
   const [smoothness, setSmoothness] = useState(0.5);
+  const [plotsVisible, setPlotsVisible] = useState(0b111);
+
+  const toggleSpeedPlot = () => {
+    setPlotsVisible(plotsVisible ^ PLOT_MASK.speed);
+  };
+
+  const toggleAccuracyPlot = () => {
+    setPlotsVisible(plotsVisible ^ PLOT_MASK.accuracy);
+  };
+
+  const toggleComplexityPlot = () => {
+    setPlotsVisible(plotsVisible ^ PLOT_MASK.complexity);
+  };
 
   return (
     <Figure>
@@ -34,6 +47,7 @@ export function SpeedChartSection({ results }: { results: readonly Result[] }) {
           smoothness={smoothness}
           width="100%"
           height="25rem"
+          plotsVisible={plotsVisible}
         />
       </ChartWrapper>
 
@@ -48,9 +62,21 @@ export function SpeedChartSection({ results }: { results: readonly Result[] }) {
           id="profile.chart.speed.legend"
           defaultMessage="Horizontal axis: lesson number. Vertical axis: {label1} – typing speed, {label2} – typing accuracy, {label3} – number of keys in the lessons."
           values={{
-            label1: <Marker type="speed" />,
-            label2: <Marker type="accuracy" />,
-            label3: <Marker type="complexity" />,
+            label1: (
+              <span onClick={toggleSpeedPlot}>
+                <Marker type="speed" />
+              </span>
+            ),
+            label2: (
+              <span onClick={toggleAccuracyPlot}>
+                <Marker type="accuracy" />
+              </span>
+            ),
+            label3: (
+              <span onClick={toggleComplexityPlot}>
+                <Marker type="complexity" />
+              </span>
+            ),
           }}
         />
       </Figure.Legend>

--- a/packages/page-profile/lib/profile/SpeedChartSection.tsx
+++ b/packages/page-profile/lib/profile/SpeedChartSection.tsx
@@ -9,7 +9,7 @@ import { SmoothnessRange } from "./SmoothnessRange.tsx";
 
 export function SpeedChartSection({ results }: { results: readonly Result[] }) {
   const [smoothness, setSmoothness] = useState(0.5);
-  const [plotsVisible, setPlotsVisible] = useState(0b111);
+  const [plotsVisible, setPlotsVisible] = useState(PLOT_MASK.all);
 
   const toggleSpeedPlot = () => {
     setPlotsVisible(plotsVisible ^ PLOT_MASK.speed);


### PR DESCRIPTION
Implements feature request #283 
Users can individually toggle visibility of speed, accuracy, and complexity scatter-plots by clicking the corresponding coloured markers under the "Typing Speed" chart or "solo" the given plot by hovering over the corresponding marker.