### PR TITLE
Visually uncheck keyboard emulation checkbox if emulation is false

### DIFF
--- a/packages/page-practice/lib/settings/KeyboardSettings.tsx
+++ b/packages/page-practice/lib/settings/KeyboardSettings.tsx
@@ -118,6 +118,7 @@ function LayoutProp(): ReactNode {
         <Field>
           <CheckBox
             checked={
+              options.layout.emulate &&
               settings.get(keyboardProps.emulation) === Emulation.Forward
             }
             disabled={!options.layout.emulate}


### PR DESCRIPTION
Disables the checkbox for non emulating keyboard layouts as mentione in #386