### PR TITLE
Hide letter/key statistics popup when the user starts typing

### DIFF
--- a/packages/page-practice/lib/practice/Indicators.tsx
+++ b/packages/page-practice/lib/practice/Indicators.tsx
@@ -8,7 +8,7 @@ import {
   names,
   StreakListRow,
 } from "@keybr/lesson-ui";
-import { Popup, Portal } from "@keybr/widget";
+import { Popup, Portal, useWindowEvent } from "@keybr/widget";
 import { memo, type ReactNode, useEffect, useState } from "react";
 import * as styles from "./Indicators.module.less";
 import { KeyExtendedDetails } from "./KeyExtendedDetails.tsx";
@@ -26,6 +26,14 @@ export const Indicators = memo(function Indicators({
     | { type: "visible-out"; key: LessonKey; elem: Element }
   >;
   const [state, setState] = useState<State>({ type: "hidden" });
+  useWindowEvent("keydown", (e: KeyboardEvent) => {
+    const isKeyPrintable = e.key.length === 1;
+    const isPopupVisible =
+      state.type === "visible" || state.type === "visible-in";
+    if (isKeyPrintable && isPopupVisible) {
+      setState({ type: "hidden" });
+    }
+  });
   useEffect(() => {
     const tasks = new Tasks();
     switch (state.type) {


### PR DESCRIPTION
### Summary

This pull request addresses issue #503.

### Changes

- Added call to the `useWindowEvent` from `@keybr/widget` into the `packages/page-practice/lib/practice/Indicators.tsx` file. 
	- This approach seemed to be the most idiomatic solution to the problem, and has been manually tested to be working within the practice page with no unintended consequences (via Docker). While hovering over an indicator key, the popup will display, and when the user starts typing, it will hide itself until the user re-hovers over it.
	- It currently supports all non-modifier/non-function keys that I have tested (those that would be seen in the word set). Adding <kbd>Esc</kbd> support was a consideration, but this was scrapped due to the undesired behaviour of requiring double inputs as the 'hide the practice words' listener takes priority in the collision.

```mermaid
flowchart TD
    Hover["User hovers over indicator key"] --> ShowPopup["Popup displays"]

    ShowPopup --> KeyAction{"User presses a key"}
    KeyAction -- Non-Modifier Key (with or without modifier held) --> HidePopup["Popup hides"]

    HidePopup --> Rehover["User re-hovers over indicator key"]
    Rehover --> ShowPopup
```

