### PR TITLE
Additions and changes to diacritics (Implements #533 and #534)

### DIFF
--- a/packages/keybr-keyboard-io/lib/parser/diacritics.ts
+++ b/packages/keybr-keyboard-io/lib/parser/diacritics.ts
@@ -19,6 +19,7 @@ const forwardMap = new Map([
   [/* CEDILLA */ 0x00b8, /* COMBINING CEDILLA */ 0x0327],
   [/* OGONEK */ 0x02db, /* COMBINING OGONEK */ 0x0328],
   [/* GREEK TONOS */ 0x0384, /* COMBINING ACUTE ACCENT */ 0x0301],
+  [/* SOLIDUS */ 0x002F, /* COMBINING SHORT SOLIDUS OVERLAY */ 0x0337],
 ]);
 
 const reverseMap = new Map([...forwardMap].map(([key, value]) => [value, key]));

--- a/packages/keybr-unicode/lib/diacritics.ts
+++ b/packages/keybr-unicode/lib/diacritics.ts
@@ -85,8 +85,8 @@ for (const [codePoint, baseList, combinedList] of [
   ],
   [
     /* COMBINING CEDILLA */ 0x0327, //
-    "CDEGHKLNRSTcdeghklnrst",
-    "ÇḐȨĢḨĶĻŅŖŞŢçḑȩģḩķļņŗşţ",
+    "ACDEGHIKLNORSTUacdeghiklnorstu",
+    "ĄÇḐĘĢḨĮĶĻŅǪŖŞŢŲąçḑęģḩįķļņǫŗşţų",
   ],
   [
     /* COMBINING OGONEK */ 0x0328, //

--- a/packages/keybr-unicode/lib/diacritics.ts
+++ b/packages/keybr-unicode/lib/diacritics.ts
@@ -93,6 +93,11 @@ for (const [codePoint, baseList, combinedList] of [
     "AEIOUaeiou",
     "ĄĘĮǪŲąęįǫų",
   ],
+  [
+    /* COMBINING SHORT SOLIDUS OVERLAY */ 0x0337, //
+    "ABCDEGHIJLOPRTUYZabcdeghijlortuyz",
+    "ȺɃȻĐɆǤĦƗɟŁØⱣɌŦɄɎƵⱥƀȼđɇǥħɨɟłøɍŧʉɏƶ",
+  ],
 ] as [CodePoint, string, string][]) {
   for (let i = 0; i < baseList.length; i++) {
     const base = baseList.codePointAt(i)!;


### PR DESCRIPTION
Implement two proposed changes.

Note for #533:
Added mapping for all five vowels, the original proposed change only had A and E

Note for #534 
Follows the proposed variant 2