### PR TITLE
fix(docker): usage of npm ci instead of npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 COPY . .
 
 # Install dependencies
-RUN npm install
+RUN npm ci
 
 # Compile monorepo and build bundle
 RUN npm run compile && npm run build


### PR DESCRIPTION
Prefer the usage of npm ci to ensure build reproductability, efficiency and prevent the change of dependencies versions