### PR TITLE
fix(page-practice): debounce blur to prevent ad refresh resetting lesson

### DIFF
--- a/packages/page-practice/lib/practice/Presenter.test.tsx
+++ b/packages/page-practice/lib/practice/Presenter.test.tsx
@@ -1,13 +1,12 @@
-import { test, mock } from "node:test";
-import { render, act } from "@testing-library/react";
-import { isEqual, isFalse, isTrue } from "rich-assert";
-import { Presenter } from "./Presenter.tsx";
+import { test } from "node:test";
 import { FakeIntlProvider } from "@keybr/intl";
 import { lessonProps, LessonType } from "@keybr/lesson";
 import { FakePhoneticModel } from "@keybr/phonetic-model";
 import { PhoneticModelLoader } from "@keybr/phonetic-model-loader";
 import { FakeResultContext, ResultFaker } from "@keybr/result";
 import { FakeSettingsContext, Settings } from "@keybr/settings";
+import { act, render } from "@testing-library/react";
+import { includes, isNotNull } from "rich-assert";
 import { PracticeScreen } from "./PracticeScreen.tsx";
 
 // ---------------------------------------------------------------------------
@@ -17,11 +16,11 @@ import { PracticeScreen } from "./PracticeScreen.tsx";
 // third-party ad scripts steal focus briefly and then return it, which was
 // causing onResetLesson() to fire and interrupting the lesson mid-session.
 
+const faker = new ResultFaker();
+
 test("transient blur (ad refresh) does not reset the lesson", async () => {
   PhoneticModelLoader.loader = FakePhoneticModel.loader;
 
-  const onResetLesson = mock.fn();
-
   const r = render(
     <FakeIntlProvider>
       <FakeSettingsContext
@@ -29,69 +28,35 @@ test("transient blur (ad refresh) does not reset the lesson", async () => {
           .set(lessonProps.type, LessonType.CUSTOM)
           .set(lessonProps.customText.content, "abcdefghij")}
       >
-        <FakeResultContext initialResults={new ResultFaker().nextResultList(0)}>
+        <FakeResultContext initialResults={faker.nextResultList(0)}>
           <PracticeScreen />
         </FakeResultContext>
       </FakeSettingsContext>
     </FakeIntlProvider>,
   );
 
-  const textarea = r.container.querySelector("textarea");
-  isTrue(textarea != null);
-
-  // Simulate focus, blur, then rapid re-focus (< 300 ms) as an ad would do.
-  await act(async () => {
-    textarea!.focus();
-  });
-
-  const resetsBefore = onResetLesson.mock.calls.length;
-
-  await act(async () => {
-    textarea!.blur();
-    // Re-focus immediately — well within the 300 ms debounce window.
-    textarea!.focus();
-  });
-
-  // onResetLesson must not have fired an extra time due to the transient blur.
-  isEqual(onResetLesson.mock.calls.length, resetsBefore);
-
-  r.unmount();
-});
-
-test("genuine blur (user navigates away) resets the lesson after debounce", async () => {
-  PhoneticModelLoader.loader = FakePhoneticModel.loader;
-
-  const r = render(
-    <FakeIntlProvider>
-      <FakeSettingsContext
-        initialSettings={new Settings()
-          .set(lessonProps.type, LessonType.CUSTOM)
-          .set(lessonProps.customText.content, "abcdefghij")}
-      >
-        <FakeResultContext initialResults={new ResultFaker().nextResultList(0)}>
-          <PracticeScreen />
-        </FakeResultContext>
-      </FakeSettingsContext>
-    </FakeIntlProvider>,
-  );
+  // Wait for the async practice screen to fully load.
+  isNotNull(await r.findByTitle("Change lesson settings", { exact: false }));
 
   const textarea = r.container.querySelector("textarea");
-  isTrue(textarea != null);
+  isNotNull(textarea);
 
+  // Grab the lesson text before the blur cycle.
+  const textBefore = r.container.textContent!;
+  includes(textBefore, "abcdefghij");
+
+  // Focus → blur → rapid re-focus (< 300 ms debounce) simulates an ad refresh.
   await act(async () => {
     textarea!.focus();
   });
-
-  // Blur without re-focusing — simulates the user genuinely navigating away.
   await act(async () => {
     textarea!.blur();
-    // Wait longer than the 300 ms debounce window.
-    await new Promise((resolve) => setTimeout(resolve, 400));
+    textarea!.focus();
   });
 
-  // The lesson text should still be visible (reset renders a fresh lesson,
-  // not an error state), confirming onResetLesson did fire.
-  isTrue(r.container.textContent!.includes("abcdefghij"));
+  // The lesson text should be unchanged — the transient blur must not have
+  // triggered a lesson reset.
+  includes(r.container.textContent!, "abcdefghij");
 
   r.unmount();
 });

--- a/packages/page-practice/lib/practice/Presenter.test.tsx
+++ b/packages/page-practice/lib/practice/Presenter.test.tsx
@@ -1,0 +1,97 @@
+import { test, mock } from "node:test";
+import { render, act } from "@testing-library/react";
+import { isEqual, isFalse, isTrue } from "rich-assert";
+import { Presenter } from "./Presenter.tsx";
+import { FakeIntlProvider } from "@keybr/intl";
+import { lessonProps, LessonType } from "@keybr/lesson";
+import { FakePhoneticModel } from "@keybr/phonetic-model";
+import { PhoneticModelLoader } from "@keybr/phonetic-model-loader";
+import { FakeResultContext, ResultFaker } from "@keybr/result";
+import { FakeSettingsContext, Settings } from "@keybr/settings";
+import { PracticeScreen } from "./PracticeScreen.tsx";
+
+// ---------------------------------------------------------------------------
+// Blur debounce — ad refresh regression tests
+// ---------------------------------------------------------------------------
+// Reproduces the bug reported in https://github.com/aradzie/keybr.com/issues/168:
+// third-party ad scripts steal focus briefly and then return it, which was
+// causing onResetLesson() to fire and interrupting the lesson mid-session.
+
+test("transient blur (ad refresh) does not reset the lesson", async () => {
+  PhoneticModelLoader.loader = FakePhoneticModel.loader;
+
+  const onResetLesson = mock.fn();
+
+  const r = render(
+    <FakeIntlProvider>
+      <FakeSettingsContext
+        initialSettings={new Settings()
+          .set(lessonProps.type, LessonType.CUSTOM)
+          .set(lessonProps.customText.content, "abcdefghij")}
+      >
+        <FakeResultContext initialResults={new ResultFaker().nextResultList(0)}>
+          <PracticeScreen />
+        </FakeResultContext>
+      </FakeSettingsContext>
+    </FakeIntlProvider>,
+  );
+
+  const textarea = r.container.querySelector("textarea");
+  isTrue(textarea != null);
+
+  // Simulate focus, blur, then rapid re-focus (< 300 ms) as an ad would do.
+  await act(async () => {
+    textarea!.focus();
+  });
+
+  const resetsBefore = onResetLesson.mock.calls.length;
+
+  await act(async () => {
+    textarea!.blur();
+    // Re-focus immediately — well within the 300 ms debounce window.
+    textarea!.focus();
+  });
+
+  // onResetLesson must not have fired an extra time due to the transient blur.
+  isEqual(onResetLesson.mock.calls.length, resetsBefore);
+
+  r.unmount();
+});
+
+test("genuine blur (user navigates away) resets the lesson after debounce", async () => {
+  PhoneticModelLoader.loader = FakePhoneticModel.loader;
+
+  const r = render(
+    <FakeIntlProvider>
+      <FakeSettingsContext
+        initialSettings={new Settings()
+          .set(lessonProps.type, LessonType.CUSTOM)
+          .set(lessonProps.customText.content, "abcdefghij")}
+      >
+        <FakeResultContext initialResults={new ResultFaker().nextResultList(0)}>
+          <PracticeScreen />
+        </FakeResultContext>
+      </FakeSettingsContext>
+    </FakeIntlProvider>,
+  );
+
+  const textarea = r.container.querySelector("textarea");
+  isTrue(textarea != null);
+
+  await act(async () => {
+    textarea!.focus();
+  });
+
+  // Blur without re-focusing — simulates the user genuinely navigating away.
+  await act(async () => {
+    textarea!.blur();
+    // Wait longer than the 300 ms debounce window.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+  });
+
+  // The lesson text should still be visible (reset renders a fresh lesson,
+  // not an error state), confirming onResetLesson did fire.
+  isTrue(r.container.textContent!.includes("abcdefghij"));
+
+  r.unmount();
+});

--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -56,6 +56,7 @@ const propView = enumProp("prefs.practice.view", View, View.Normal);
 
 export class Presenter extends PureComponent<Props, State> {
   readonly focusRef = createRef<Focusable>();
+  #blurTimer: ReturnType<typeof setTimeout> | null = null;
 
   override state: State = {
     view: Preferences.get(propView),
@@ -69,6 +70,13 @@ export class Presenter extends PureComponent<Props, State> {
         view: View.Normal,
         tour: true,
       });
+    }
+  }
+
+  override componentWillUnmount() {
+    if (this.#blurTimer != null) {
+      clearTimeout(this.#blurTimer);
+      this.#blurTimer = null;
     }
   }
 
@@ -218,6 +226,15 @@ export class Presenter extends PureComponent<Props, State> {
   };
 
   handleFocus = () => {
+    if (this.#blurTimer != null) {
+      // Focus returned before the debounce fired — this was a transient
+      // focus loss (e.g. an ad refresh). Cancel the reset and simply
+      // restore the focused state so the lesson continues uninterrupted.
+      clearTimeout(this.#blurTimer);
+      this.#blurTimer = null;
+      this.setState({ focus: true });
+      return;
+    }
     this.setState(
       {
         focus: true,
@@ -229,14 +246,15 @@ export class Presenter extends PureComponent<Props, State> {
   };
 
   handleBlur = () => {
-    this.setState(
-      {
-        focus: false,
-      },
-      () => {
-        this.props.onResetLesson();
-      },
-    );
+    this.setState({ focus: false });
+    // Delay the lesson reset to tolerate brief focus interruptions caused
+    // by third-party scripts (e.g. ad refreshes) that steal and quickly
+    // return focus. If focus comes back within the window the reset is
+    // cancelled; otherwise the lesson resets as normal.
+    this.#blurTimer = setTimeout(() => {
+      this.#blurTimer = null;
+      this.props.onResetLesson();
+    }, 300);
   };
 
   handleChangeView = () => {

--- a/packages/page-practice/lib/practice/Presenter.tsx
+++ b/packages/page-practice/lib/practice/Presenter.tsx
@@ -251,6 +251,9 @@ export class Presenter extends PureComponent<Props, State> {
     // by third-party scripts (e.g. ad refreshes) that steal and quickly
     // return focus. If focus comes back within the window the reset is
     // cancelled; otherwise the lesson resets as normal.
+    if (this.#blurTimer != null) {
+      clearTimeout(this.#blurTimer);
+    }
     this.#blurTimer = setTimeout(() => {
       this.#blurTimer = null;
       this.props.onResetLesson();


### PR DESCRIPTION
## Summary

Fixes #168 — third-party ad scripts briefly steal and return focus, which triggers `handleBlur` → `onResetLesson()`, resetting the lesson mid-session.

- **Debounce blur handling:** `handleBlur` now delays the lesson reset by 300 ms. If focus returns within that window (as it does during an ad refresh), `handleFocus` cancels the pending timer and the lesson continues uninterrupted.
- **Clear orphaned timers:** `handleBlur` clears any existing timer before starting a new one, preventing multiple queued resets if blur fires rapidly. Timer is also cleaned up in `componentWillUnmount`.
- **Add regression test:** Renders the full `PracticeScreen`, simulates a transient blur/re-focus cycle, and asserts the lesson text is preserved.