### PR TITLE
feat: add "train second key" guided lesson option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,9 @@ sandbox/
 *.bak
 *~
 
+# Playwright
+test-results/
+playwright-report/
+
 # Custom scripts
 deploy.sh

--- a/e2e/guided-lesson/alphabet-size-churn.spec.ts
+++ b/e2e/guided-lesson/alphabet-size-churn.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+import {
+  announcedCodePoints,
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  mulberry32,
+  randomDelay,
+  readAppliedSettings,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+test("alphabetSize > 0 force-includes several keys at once", async ({
+  page,
+}) => {
+  // Sized for the keystroke budget's worst case, not just the typical
+  // case, so an unlucky seed fails its own assertion, not a timeout.
+  test.setTimeout(5 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(
+    `alphabetSize churn seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`,
+  );
+  const random = mulberry32(seed);
+  const SETUP_KEYSTROKE_BUDGET = 3000;
+  const ALPHABET_SIZE = 0.3;
+  const minSize = 6;
+
+  const baseSettings = {
+    "lesson.type": "guided",
+    "keyboard.layout": "en-us",
+  };
+  await page.addInitScript((settings) => {
+    localStorage.setItem("settings", JSON.stringify(settings));
+  }, baseSettings);
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  const maxSize =
+    minSize + Math.round((alphabet.length - minSize) * ALPHABET_SIZE);
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+
+  // Get a few keys included first, to check continuity across the churn.
+  while (
+    keystrokes < SETUP_KEYSTROKE_BUDGET &&
+    alphabet.filter((cp) => keys.get(cp)!.included).length < 7
+  ) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const cp of alphabet) {
+      if (keys.get(cp)!.included && !next.get(cp)!.included) {
+        throw new Error(
+          `Key ${cp} regressed before churning alphabetSize after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    keys = next;
+  }
+  const includedBefore = alphabet.filter((cp) => keys.get(cp)!.included);
+  expect(
+    includedBefore.length,
+    `expected at least 7 keys included before churning alphabetSize within ${SETUP_KEYSTROKE_BUDGET} keystrokes (seed ${seed})`,
+  ).toBeGreaterThanOrEqual(7);
+
+  // addInitScript, not evaluate: the base settings init script above
+  // reruns on every navigation including reload, clobbering a plain write.
+  await page.addInitScript(
+    (settings) => {
+      localStorage.setItem("settings", JSON.stringify(settings));
+    },
+    { ...baseSettings, "lesson.guided.alphabetSize": ALPHABET_SIZE },
+  );
+  await page.reload();
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  expect(
+    (await readAppliedSettings(page))["lesson.guided.alphabetSize"],
+    `expected the alphabetSize change to have actually taken effect (seed ${seed})`,
+  ).toBe(ALPHABET_SIZE);
+
+  // GuidedLesson.update() rebuilds LessonKeys from scratch every call, so
+  // this applies the instant the page (re)mounts - no typing needed.
+  const afterReload = await snapshotKeys(page);
+  const includedAfter = alphabet.filter((cp) => afterReload.get(cp)!.included);
+  const forcedAfter = alphabet.filter((cp) => afterReload.get(cp)!.forced);
+  const announcedAfter = await announcedCodePoints(page);
+  // Progress replays persisted results through append() with a no-op
+  // listener (progress.ts's seed()/seedAsync()), so nothing included this
+  // way, forced or not, ever gets a "New letter unlocked" toast.
+  for (const cp of forcedAfter) {
+    expect(
+      announcedAfter,
+      `expected no "New letter unlocked" toast for forced key ${cp} (seed ${seed})`,
+    ).not.toContain(cp);
+  }
+
+  for (const cp of includedBefore) {
+    expect(
+      afterReload.get(cp)!.included,
+      `expected previously-included key ${cp} to still be included after raising alphabetSize (seed ${seed})`,
+    ).toBe(true);
+  }
+  expect(
+    includedAfter.length,
+    `expected at least ${Math.min(maxSize, alphabet.length)} keys included once alphabetSize forces up to maxSize=${maxSize} (seed ${seed})`,
+  ).toBeGreaterThanOrEqual(Math.min(maxSize, alphabet.length));
+  expect(
+    forcedAfter.length,
+    `expected some forced keys once alphabetSize is ${ALPHABET_SIZE} (seed ${seed})`,
+  ).toBeGreaterThan(0);
+  expect(
+    forcedAfter.length,
+    `expected at most maxSize-minSize=${maxSize - minSize} forced keys (seed ${seed})`,
+  ).toBeLessThanOrEqual(maxSize - minSize);
+  for (const cp of forcedAfter) {
+    expect(
+      afterReload.get(cp)!.uncalibrated,
+      `expected freshly-forced key ${cp} to be uncalibrated (seed ${seed})`,
+    ).toBe(true);
+  }
+});

--- a/e2e/guided-lesson/alphabet-unlock.spec.ts
+++ b/e2e/guided-lesson/alphabet-unlock.spec.ts
@@ -1,0 +1,189 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+  announcedCodePoints,
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  type KeySnapshot,
+  MAX_KEYSTROKES,
+  mulberry32,
+  randomDelay,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+const CURRENT_KEY_SELECTOR = '[id*="currentKey"] [data-code-point]';
+
+test("typing through the full American English alphabet never regresses an unlocked key", async ({
+  page,
+}) => {
+  // Scoped to this test only, since a fuzz test's worst-case runtime
+  // varies a lot by seed - the other tests should keep failing fast.
+  test.setTimeout(15 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(`fuzz seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`);
+  const random = mulberry32(seed);
+
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  expect(alphabet.length).toBeGreaterThan(0);
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+  // True once past the initial minSize batch, when only one key is ever
+  // sub-threshold at a time and "target only advances" becomes guaranteed.
+  let bootstrapped = false;
+  let previousFocused: string | null = null;
+  const seenFocused = new Set<string>();
+
+  for (const codePoint of alphabet) {
+    if (keys.get(codePoint)!.included) {
+      expect(
+        keys.get(codePoint)!.uncalibrated,
+        `expected initially-included key ${codePoint} to start uncalibrated (seed ${seed})`,
+      ).toBe(true);
+    }
+  }
+
+  while (keystrokes < MAX_KEYSTROKES && !allIncluded(keys, alphabet)) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const codePoint of alphabet) {
+      if (keys.get(codePoint)!.included && !next.get(codePoint)!.included) {
+        throw new Error(
+          `Key ${codePoint} regressed from included to excluded after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    // Only holds with default alphabetSize: 0 / recoverKeys: false;
+    // GuidedLesson.update() can force several keys at once otherwise.
+    const newlyIncluded = alphabet.filter(
+      (cp) => !keys.get(cp)!.included && next.get(cp)!.included,
+    );
+    expect(
+      newlyIncluded.length,
+      `expected at most one newly-included key per round, got [${newlyIncluded}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toBeLessThanOrEqual(1);
+
+    // The "force" branch only triggers when alphabetSize > 0.
+    const forced = alphabet.filter((cp) => next.get(cp)!.forced);
+    expect(
+      forced,
+      `expected no forced keys under default alphabetSize: 0, got [${forced}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toEqual([]);
+
+    // "Current key" must match the key set's own focused key, and be
+    // included.
+    const focusedInSet = alphabet.filter((cp) => next.get(cp)!.focused);
+    const currentFocused = await currentKeyCodePoint(page);
+    expect(
+      focusedInSet.length,
+      `expected at most one focused key in the key set, got [${focusedInSet}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toBeLessThanOrEqual(1);
+    expect(
+      focusedInSet,
+      `"Current key" (${currentFocused}) doesn't match the key set's focused key(s) [${focusedInSet}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toEqual(currentFocused == null ? [] : [currentFocused]);
+    if (currentFocused != null) {
+      expect(
+        next.get(currentFocused)!.included,
+        `target key ${currentFocused} isn't marked included after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toBe(true);
+    }
+
+    // A freshly-included key starts uncalibrated (weakest), so it must
+    // immediately become the target.
+    if (newlyIncluded.length === 1) {
+      expect(
+        currentFocused,
+        `expected the newly-included key ${newlyIncluded[0]} to become the new target key, but the target key is ${currentFocused} after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toEqual(newlyIncluded[0]);
+
+      // Toaster.tsx renders newest-first, so index 0 is this round's toast.
+      const announced = await announcedCodePoints(page);
+      expect(
+        announced[0],
+        `expected the newest "New letter unlocked" toast to be for ${newlyIncluded[0]}, got toasts for [${announced}] after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toEqual(newlyIncluded[0]);
+
+      expect(
+        next.get(newlyIncluded[0])!.uncalibrated,
+        `expected freshly-included key ${newlyIncluded[0]} to start uncalibrated (no samples yet) after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toBe(true);
+
+      bootstrapped = true;
+    }
+
+    if (bootstrapped && currentFocused !== previousFocused) {
+      if (previousFocused != null) {
+        expect(
+          next.get(previousFocused)!.uncalibrated,
+          `expected ${previousFocused} to have accumulated real timing samples before the target moved on, but it's still uncalibrated after ${keystrokes} keystrokes (seed ${seed})`,
+        ).toBe(false);
+      }
+      if (currentFocused != null) {
+        expect(
+          seenFocused.has(currentFocused),
+          `target key moved back to ${currentFocused}, which was already the target key earlier - it should only ever advance, never return, after ${keystrokes} keystrokes (seed ${seed})`,
+        ).toBe(false);
+        seenFocused.add(currentFocused);
+      }
+      previousFocused = currentFocused;
+    }
+
+    keys = next;
+  }
+
+  const stillExcluded = alphabet.filter((cp) => !keys.get(cp)!.included);
+  expect(
+    stillExcluded,
+    `alphabet not fully unlocked within ${MAX_KEYSTROKES} keystrokes (seed ${seed}); still excluded: [${stillExcluded}]`,
+  ).toEqual([]);
+});
+
+function allIncluded(
+  keys: Map<string, KeySnapshot>,
+  alphabet: readonly string[],
+): boolean {
+  return alphabet.every((cp) => keys.get(cp)!.included);
+}
+
+async function currentKeyCodePoint(page: Page): Promise<string | null> {
+  const locator = page.locator(CURRENT_KEY_SELECTOR);
+  if ((await locator.count()) === 0) {
+    return null;
+  }
+  return locator.first().getAttribute("data-code-point");
+}

--- a/e2e/guided-lesson/alphabet-unlock.spec.ts
+++ b/e2e/guided-lesson/alphabet-unlock.spec.ts
@@ -10,9 +10,12 @@ import {
   roundTextSignature,
   sendChar,
   snapshotKeys,
+  SPACE_GLYPHS,
 } from "./helpers.ts";
 
 const CURRENT_KEY_SELECTOR = '[id*="currentKey"] [data-code-point]';
+const CURRENT_KEY_DETAILS_SELECTOR = '[id*="currentKey"] [class*="keyDetails"]';
+const FUMBLE_PROBABILITY = 0.15;
 
 test("typing through the full American English alphabet never regresses an unlocked key", async ({
   page,
@@ -68,11 +71,37 @@ test("typing through the full American English alphabet never regresses an unloc
       .locator(CURSOR_SELECTOR)
       .first()
       .textContent();
-    await sendChar(page, displayedChar ?? "");
+    const targetBeforeChar = await currentKeyCodePoint(page);
+    const detailsBeforeChar =
+      targetBeforeChar != null ? await currentKeyDetailsText(page) : null;
+    const fumbled = random() < FUMBLE_PROBABILITY;
+    if (fumbled) {
+      await fumbleThenCorrect(page, displayedChar ?? "", random);
+    } else {
+      await sendChar(page, displayedChar ?? "");
+    }
     keystrokes++;
     await page.waitForTimeout(delay);
 
     const signature = await roundTextSignature(page);
+    if (fumbled && targetBeforeChar != null) {
+      const targetAfterChar = await currentKeyCodePoint(page);
+      if (
+        targetAfterChar === targetBeforeChar &&
+        // The fumble's correct char may complete the round; appending a
+        // Result updates this key's samples from its other occurrences.
+        signature === roundSignature
+      ) {
+        // Histogram.from() skips a typo'd step's timing sample, so a
+        // fumble must not move this key's confidence.
+        const detailsAfterChar = await currentKeyDetailsText(page);
+        expect(
+          detailsAfterChar,
+          `expected fumbling ${targetBeforeChar} not to change its reported confidence (a miss records no timing sample), but it went from "${detailsBeforeChar}" to "${detailsAfterChar}" after ${keystrokes} keystrokes (seed ${seed})`,
+        ).toEqual(detailsBeforeChar);
+      }
+    }
+
     if (signature === roundSignature) {
       continue;
     }
@@ -186,4 +215,35 @@ async function currentKeyCodePoint(page: Page): Promise<string | null> {
     return null;
   }
   return locator.first().getAttribute("data-code-point");
+}
+
+async function currentKeyDetailsText(page: Page): Promise<string | null> {
+  const locator = page.locator(CURRENT_KEY_DETAILS_SELECTOR);
+  if ((await locator.count()) === 0) {
+    return null;
+  }
+  return locator.first().textContent();
+}
+
+const ALPHANUMERIC_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+function randomAlphanumericChar(random: () => number, exclude: string): string {
+  let char: string;
+  do {
+    char = ALPHANUMERIC_CHARS[Math.floor(random() * ALPHANUMERIC_CHARS.length)];
+  } while (char === exclude);
+  return char;
+}
+
+// TextInput.appendChar() never turns a wrong char into a step; only the
+// following correct char does, tagged Attr.Miss.
+async function fumbleThenCorrect(
+  page: Page,
+  displayed: string,
+  random: () => number,
+): Promise<void> {
+  const correct = SPACE_GLYPHS.has(displayed) ? " " : displayed;
+  const wrong = randomAlphanumericChar(random, correct);
+  await page.keyboard.type(wrong);
+  await sendChar(page, displayed);
 }

--- a/e2e/guided-lesson/daily-goal-toast.spec.ts
+++ b/e2e/guided-lesson/daily-goal-toast.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import {
+  CURSOR_SELECTOR,
+  MAX_KEYSTROKES,
+  roundTextSignature,
+  sendChar,
+  TOASTER_SELECTOR,
+} from "./helpers.ts";
+
+test("reaching the daily goal shows a 'Daily goal reached!' toast", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+        // Minutes; tiny so the goal is crossed the instant the first
+        // round's Result is recorded.
+        "lesson.dailyGoal": 0.001,
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const cursor = page.locator(CURSOR_SELECTOR).first();
+  let roundSignature = await roundTextSignature(page);
+  for (
+    let i = 0;
+    i < MAX_KEYSTROKES && (await roundTextSignature(page)) === roundSignature;
+    i++
+  ) {
+    const displayed = await cursor.textContent();
+    await sendChar(page, displayed ?? "");
+    // Histogram.validateSample() rejects samples under 40ms as implausibly
+    // fast (anti-cheat), which would make the whole Result invalid.
+    await page.waitForTimeout(50);
+  }
+
+  await expect(
+    page.locator(TOASTER_SELECTOR).getByText("Daily goal reached!"),
+  ).toBeVisible();
+});

--- a/e2e/guided-lesson/helpers.ts
+++ b/e2e/guided-lesson/helpers.ts
@@ -1,0 +1,81 @@
+import { type Page } from "@playwright/test";
+import Rand, { PRNG } from "rand-seed";
+
+export const CURSOR_SELECTOR = '[class*="chars-module__cursor"]';
+export const KEY_SET_SELECTOR = '[id*="keySet"] [data-code-point]';
+export const TOASTER_SELECTOR = '[class*="Toaster-module__toaster"]';
+export const ANNOUNCEMENT_KEY_SELECTOR = `${TOASTER_SELECTOR} [data-code-point]`;
+// Scoped past the TextArea wrapper, whose own status messages flicker
+// independently of the round.
+export const ROUND_SIGNATURE_SELECTOR = '[class*="TextLines-module__root"]';
+
+export const MAX_KEYSTROKES = 10000;
+export const MIN_DELAY_MS = 5;
+export const MAX_DELAY_MS = 60;
+
+// chars.tsx's specialChar() substitutes these for whitespace; map back to a
+// real space to send.
+export const SPACE_GLYPHS = new Set(["\u00A0", "\uE000", "\uE001"]); // nbsp, bullet, bar
+
+// Deterministic PRNG so a failing run's seed can be logged and replayed.
+export function mulberry32(seed: number): () => number {
+  const rand = new Rand(String(seed), PRNG.mulberry32);
+  return () => rand.next();
+}
+
+export function randomDelay(random: () => number): number {
+  return MIN_DELAY_MS + random() * (MAX_DELAY_MS - MIN_DELAY_MS);
+}
+
+export type KeySnapshot = {
+  readonly included: boolean;
+  readonly focused: boolean;
+  readonly uncalibrated: boolean;
+  readonly forced: boolean;
+};
+
+export async function snapshotKeys(
+  page: Page,
+): Promise<Map<string, KeySnapshot>> {
+  const entries = await page.locator(KEY_SET_SELECTOR).evaluateAll((els) =>
+    els.map((el) => [
+      el.getAttribute("data-code-point")!,
+      {
+        included: el.className.includes("lessonKey_included"),
+        focused: el.className.includes("lessonKey_focused"),
+        uncalibrated: el.className.includes("lessonKey_uncalibrated"),
+        forced: el.className.includes("lessonKey_forced"),
+      },
+    ]),
+  );
+  return new Map(entries as [string, KeySnapshot][]);
+}
+
+export async function announcedCodePoints(page: Page): Promise<string[]> {
+  return page
+    .locator(ANNOUNCEMENT_KEY_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+}
+
+// Confirms a settings change reached localStorage - a downstream-effect
+// invariant alone can pass even when the write silently no-ops.
+export async function readAppliedSettings(
+  page: Page,
+): Promise<Record<string, unknown>> {
+  const raw = await page.evaluate(() => localStorage.getItem("settings"));
+  return raw == null ? {} : JSON.parse(raw);
+}
+
+export async function roundTextSignature(page: Page): Promise<string> {
+  return page
+    .locator(ROUND_SIGNATURE_SELECTOR)
+    .evaluate((el) => el.textContent ?? "");
+}
+
+export async function sendChar(page: Page, displayed: string): Promise<void> {
+  if (SPACE_GLYPHS.has(displayed)) {
+    await page.keyboard.type(" ");
+  } else {
+    await page.keyboard.type(displayed);
+  }
+}

--- a/e2e/guided-lesson/mistake-color.spec.ts
+++ b/e2e/guided-lesson/mistake-color.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { CURSOR_SELECTOR, sendChar } from "./helpers.ts";
+
+test("a corrected mistake renders in the miss color", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const cursor = page.locator(CURSOR_SELECTOR).first();
+  const expected = (await cursor.textContent()) ?? "";
+  const wrong = expected === "j" ? "k" : "j";
+
+  // Default settings reject a single wrong keystroke without moving the
+  // cursor (TextInput.appendChar()).
+  await page.keyboard.type(wrong);
+  await expect(cursor).toHaveText(expected);
+
+  await sendChar(page, expected);
+
+  // A step preceded by a typo is marked Attr.Miss even once corrected,
+  // rendered as its own single-character span right before the cursor.
+  // Asserted via this sibling rather than "cursor text changed", since the
+  // round's own (unseeded) text can repeat expected right after itself.
+  const missed = page
+    .locator(CURSOR_SELECTOR)
+    .locator("xpath=preceding-sibling::*[1]");
+  await expect(missed).toHaveText(expected);
+  const color = await missed.evaluate((el) => (el as HTMLElement).style.color);
+  expect(color).toBe("var(--textinput--miss__color)");
+});

--- a/e2e/guided-lesson/pointer-highlight.spec.ts
+++ b/e2e/guided-lesson/pointer-highlight.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+import { CURSOR_SELECTOR, sendChar, SPACE_GLYPHS } from "./helpers.ts";
+
+const POINTER_SELECTOR = '[class*="PointersLayer-module__pointer"]';
+
+test("the highlighted next key points at the correct on-screen key", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+        "keyboard.pointers": true,
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const cursor = page.locator(CURSOR_SELECTOR).first();
+  const KEYS_TO_CHECK = 5;
+  for (let i = 0; i < KEYS_TO_CHECK; i++) {
+    const displayed = (await cursor.textContent()) ?? "";
+    const expectedKeyId = SPACE_GLYPHS.has(displayed)
+      ? "Space"
+      : `Key${displayed.toUpperCase()}`;
+
+    // The pointer only appears after some hesitation delay, so poll
+    // rather than assume a fixed one.
+    const pointer = page.locator(POINTER_SELECTOR).first();
+    await expect(pointer).toBeVisible({ timeout: 5000 });
+    // It fades in via an SVG animation; let it settle before measuring.
+    await page.waitForTimeout(200);
+    const pointerBox = await pointer.boundingBox();
+    const keyBox = await page
+      .locator(`[data-key="${expectedKeyId}"]`)
+      .boundingBox();
+    expect(pointerBox, "pointer circle has no bounding box").not.toBeNull();
+    expect(
+      keyBox,
+      `no on-screen key found for ${expectedKeyId}`,
+    ).not.toBeNull();
+
+    const cx = pointerBox!.x + pointerBox!.width / 2;
+    const cy = pointerBox!.y + pointerBox!.height / 2;
+    expect(
+      cx >= keyBox!.x && cx <= keyBox!.x + keyBox!.width,
+      `expected pointer center x=${cx} to fall within key ${expectedKeyId}'s box [${keyBox!.x}, ${keyBox!.x + keyBox!.width}]`,
+    ).toBe(true);
+    expect(
+      cy >= keyBox!.y && cy <= keyBox!.y + keyBox!.height,
+      `expected pointer center y=${cy} to fall within key ${expectedKeyId}'s box [${keyBox!.y}, ${keyBox!.y + keyBox!.height}]`,
+    ).toBe(true);
+
+    await sendChar(page, displayed);
+    // Otherwise the next iteration could check the pointer before the app
+    // has cleared this character's own pointer.
+    await expect(cursor).not.toHaveText(displayed);
+  }
+});

--- a/e2e/guided-lesson/recover-keys-churn.spec.ts
+++ b/e2e/guided-lesson/recover-keys-churn.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "@playwright/test";
+import {
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  mulberry32,
+  randomDelay,
+  readAppliedSettings,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+test("recoverKeys allows a key to legitimately regress", async ({ page }) => {
+  // Sized for the keystroke budgets' worst case, not just the typical
+  // case, so an unlucky seed fails its own assertion, not a timeout.
+  test.setTimeout(6 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(
+    `recoverKeys churn seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`,
+  );
+  const random = mulberry32(seed);
+  const SETUP_KEYSTROKE_BUDGET = 3000;
+  const POST_CHURN_KEYSTROKE_BUDGET = 800;
+
+  const baseSettings = {
+    "lesson.type": "guided",
+    "keyboard.layout": "en-us",
+  };
+  await page.addInitScript((settings) => {
+    localStorage.setItem("settings", JSON.stringify(settings));
+  }, baseSettings);
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  // GuidedLesson.update() always includes these unconditionally, regardless
+  // of confidence or recoverKeys, so they can never legitimately regress.
+  const initialBatch = new Set(alphabet.slice(0, 6));
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+
+  while (
+    keystrokes < SETUP_KEYSTROKE_BUDGET &&
+    alphabet.filter((cp) => keys.get(cp)!.included).length < 7
+  ) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const cp of alphabet) {
+      if (keys.get(cp)!.included && !next.get(cp)!.included) {
+        throw new Error(
+          `Key ${cp} regressed before churning recoverKeys after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    keys = next;
+  }
+  expect(
+    alphabet.filter((cp) => keys.get(cp)!.included).length,
+    `expected at least 7 keys included before churning recoverKeys within ${SETUP_KEYSTROKE_BUDGET} keystrokes (seed ${seed})`,
+  ).toBeGreaterThanOrEqual(7);
+
+  // addInitScript, not evaluate: the base settings init script above
+  // reruns on every navigation including reload, clobbering a plain write.
+  await page.addInitScript(
+    (settings) => {
+      localStorage.setItem("settings", JSON.stringify(settings));
+    },
+    { ...baseSettings, "lesson.guided.recoverKeys": true },
+  );
+  await page.reload();
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  expect(
+    (await readAppliedSettings(page))["lesson.guided.recoverKeys"],
+    `expected the recoverKeys change to have actually taken effect (seed ${seed})`,
+  ).toBe(true);
+
+  keys = await snapshotKeys(page);
+  for (const cp of initialBatch) {
+    expect(
+      keys.get(cp)!.included,
+      `expected guaranteed initial key ${cp} to still be included right after enabling recoverKeys (seed ${seed})`,
+    ).toBe(true);
+  }
+
+  roundSignature = await roundTextSignature(page);
+  delay = randomDelay(random);
+  keystrokes = 0;
+  // recoverKeys uses live confidence, not bestConfidence, so a key beyond
+  // the initial batch can legitimately lose inclusion - not forced here.
+  let sawRegressionBeyondInitialBatch = false;
+
+  while (keystrokes < POST_CHURN_KEYSTROKE_BUDGET) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const cp of initialBatch) {
+      expect(
+        next.get(cp)!.included,
+        `expected guaranteed initial key ${cp} to never regress, even with recoverKeys, after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toBe(true);
+    }
+    for (const cp of alphabet) {
+      if (
+        !initialBatch.has(cp) &&
+        keys.get(cp)!.included &&
+        !next.get(cp)!.included
+      ) {
+        sawRegressionBeyondInitialBatch = true;
+      }
+    }
+    // The "force" branch only triggers when alphabetSize > 0.
+    const forced = alphabet.filter((cp) => next.get(cp)!.forced);
+    expect(
+      forced,
+      `expected no forced keys under default alphabetSize: 0, got [${forced}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toEqual([]);
+    keys = next;
+  }
+
+  console.log(
+    `recoverKeys regression observed beyond the initial batch: ${sawRegressionBeyondInitialBatch} (seed ${seed})`,
+  );
+});

--- a/e2e/guided-lesson/settings-churn.spec.ts
+++ b/e2e/guided-lesson/settings-churn.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "@playwright/test";
+import {
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  mulberry32,
+  randomDelay,
+  readAppliedSettings,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+test("progress survives mid-run settings changes and a target-speed ramp", async ({
+  page,
+}) => {
+  // Sized for the keystroke budget's worst case, not just the typical
+  // case, so an unlucky seed fails its own assertion, not a timeout.
+  test.setTimeout(6 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(
+    `settings-churn seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`,
+  );
+  const random = mulberry32(seed);
+  const CHURN_KEYSTROKE_BUDGET = 4000;
+
+  const baseSettings = {
+    "lesson.type": "guided",
+    "keyboard.layout": "en-us",
+    "lesson.targetSpeed": 75,
+  };
+  await page.addInitScript((settings) => {
+    localStorage.setItem("settings", JSON.stringify(settings));
+  }, baseSettings);
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  const initialBatch = new Set(alphabet.slice(0, 6));
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+
+  // naturalWords only affects word generation, not GuidedLesson.update()'s
+  // inclusion logic, so no regression is expected across this reload.
+  async function churnNaturalWords() {
+    const included = alphabet.filter((cp) => keys.get(cp)!.included);
+    const settings = {
+      ...baseSettings,
+      "lesson.guided.naturalWords": false,
+    };
+    // addInitScript, not evaluate: the base settings init script above
+    // reruns on every navigation including reload, clobbering a plain write.
+    await page.addInitScript((s) => {
+      localStorage.setItem("settings", JSON.stringify(s));
+    }, settings);
+    await page.reload();
+    await expect(page.locator("[data-code-point]").first()).toBeVisible();
+    await page.locator("textarea").first().focus();
+
+    expect(
+      (await readAppliedSettings(page))["lesson.guided.naturalWords"],
+      `expected the naturalWords change to have actually taken effect (seed ${seed})`,
+    ).toBe(false);
+
+    keys = await snapshotKeys(page);
+    for (const cp of included) {
+      expect(
+        keys.get(cp)!.included,
+        `expected key ${cp} to still be included after toggling naturalWords (seed ${seed})`,
+      ).toBe(true);
+    }
+  }
+
+  // Confidence is computed against the target, so raising it can
+  // legitimately re-lock a key beyond the guaranteed initial 6 - not
+  // asserted here; what must still hold is asserted below.
+  async function churnTargetSpeed(newTargetSpeed: number) {
+    const included = alphabet.filter((cp) => keys.get(cp)!.included);
+    const settings = {
+      ...baseSettings,
+      "lesson.guided.naturalWords": false,
+      "lesson.targetSpeed": newTargetSpeed,
+    };
+    await page.addInitScript((s) => {
+      localStorage.setItem("settings", JSON.stringify(s));
+    }, settings);
+    await page.reload();
+    await expect(page.locator("[data-code-point]").first()).toBeVisible();
+    await page.locator("textarea").first().focus();
+
+    expect(
+      (await readAppliedSettings(page))["lesson.targetSpeed"],
+      `expected the targetSpeed change to have actually taken effect (seed ${seed})`,
+    ).toBe(newTargetSpeed);
+
+    keys = await snapshotKeys(page);
+    for (const cp of alphabet) {
+      if (!included.includes(cp) && !initialBatch.has(cp)) {
+        expect(
+          keys.get(cp)!.included,
+          `expected key ${cp} not to newly qualify for inclusion just from raising the target speed to ${newTargetSpeed} (seed ${seed})`,
+        ).toBe(false);
+      }
+    }
+  }
+
+  let naturalWordsChurned = false;
+  let targetSpeedChurned = false;
+
+  while (
+    keystrokes < CHURN_KEYSTROKE_BUDGET &&
+    !(naturalWordsChurned && targetSpeedChurned)
+  ) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const codePoint of alphabet) {
+      if (keys.get(codePoint)!.included && !next.get(codePoint)!.included) {
+        throw new Error(
+          `Key ${codePoint} regressed from included to excluded after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    keys = next;
+
+    const includedCount = alphabet.filter(
+      (cp) => keys.get(cp)!.included,
+    ).length;
+    if (!naturalWordsChurned && includedCount >= 7) {
+      await churnNaturalWords();
+      naturalWordsChurned = true;
+      roundSignature = await roundTextSignature(page);
+      delay = randomDelay(random);
+    } else if (
+      naturalWordsChurned &&
+      !targetSpeedChurned &&
+      includedCount >= 8
+    ) {
+      await churnTargetSpeed(300);
+      targetSpeedChurned = true;
+      roundSignature = await roundTextSignature(page);
+      delay = randomDelay(random);
+    }
+  }
+
+  expect(
+    naturalWordsChurned && targetSpeedChurned,
+    `expected both settings changes to be exercised within ${CHURN_KEYSTROKE_BUDGET} keystrokes (seed ${seed}); naturalWordsChurned=${naturalWordsChurned}, targetSpeedChurned=${targetSpeedChurned}`,
+  ).toBe(true);
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("practice page loads and accepts typed input", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+
+  await page.locator("textarea").first().focus();
+  const textArea = page.locator('[class*="TextArea-module__root"]');
+  const before = await textArea.innerHTML();
+
+  const expectedChar = await page
+    .locator('[class*="chars-module__cursor"]')
+    .first()
+    .textContent();
+  await page.keyboard.type(expectedChar ?? "");
+
+  await expect(async () => {
+    expect(await textArea.innerHTML()).not.toEqual(before);
+  }).toPass();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@formatjs/cli-lib": "^8.5.0",
         "@formatjs/ts-transformer": "^4.4.2",
         "@jdalton/patch-package": "^8.1.1",
+        "@playwright/test": "^1.62.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -85,6 +86,7 @@
         "postcss": "^8.5.8",
         "postcss-less": "^6.0.0",
         "prettier": "^3.8.1",
+        "rand-seed": "^3.0.0",
         "rich-assert": "^0.0.3",
         "source-map-loader": "^5.0.0",
         "stylelint": "^17.6.0",
@@ -1699,6 +1701,22 @@
       },
       "engines": {
         "node": ">=20.8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -8230,6 +8248,53 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -9028,6 +9093,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/rand-seed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rand-seed/-/rand-seed-3.0.0.tgz",
+      "integrity": "sha512-Zy8wnL6whyIAGOX2i9Mn1Orq3t9TNizGUk8euxamr60Z3PmspwFeT+vCZPcYMAR5nOztnAKPtVi3jt8EzmCB6g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rc": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "build-dev": "env NODE_ENV=development webpack",
     "watch": "env NODE_ENV=development webpack --watch",
     "start": "env NODE_ENV=development node --enable-source-maps ./root/index.js",
-    "start-docker": "env NODE_ENV=production ./packages/devenv/lib/initdb.ts && env NODE_ENV=production node --enable-source-maps ./root/index.js"
+    "start-docker": "env NODE_ENV=production ./packages/devenv/lib/initdb.ts && env NODE_ENV=production node --enable-source-maps ./root/index.js",
+    "test-e2e": "playwright test"
   },
   "dependencies": {
     "@fastr/client": "^0.1.3",
@@ -76,6 +77,7 @@
     "@formatjs/cli-lib": "^8.5.0",
     "@formatjs/ts-transformer": "^4.4.2",
     "@jdalton/patch-package": "^8.1.1",
+    "@playwright/test": "^1.62.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -104,6 +106,7 @@
     "postcss": "^8.5.8",
     "postcss-less": "^6.0.0",
     "prettier": "^3.8.1",
+    "rand-seed": "^3.0.0",
     "rich-assert": "^0.0.3",
     "source-map-loader": "^5.0.0",
     "stylelint": "^17.6.0",

--- a/packages/keybr-lesson-ui/lib/Key.test.tsx
+++ b/packages/keybr-lesson-ui/lib/Key.test.tsx
@@ -57,6 +57,31 @@ test("render included", () => {
   r.unmount();
 });
 
+test("render second focused", () => {
+  const key = new LessonKey({
+    letter: FakePhoneticModel.letter1,
+    samples: [],
+    timeToType: null,
+    bestTimeToType: null,
+    confidence: null,
+    bestConfidence: null,
+  }).asSecondFocused();
+
+  const r = render(
+    <FakeIntlProvider>
+      <FakeSettingsContext>
+        <Key lessonKey={key} />
+      </FakeSettingsContext>
+    </FakeIntlProvider>,
+  );
+
+  const elem = r.container.querySelector(".lessonKey_secondFocused");
+  isNotNull(elem);
+  equal(Key.attached(elem), key);
+
+  r.unmount();
+});
+
 test("render focused", () => {
   const key = new LessonKey({
     letter: FakePhoneticModel.letter1,

--- a/packages/keybr-lesson-ui/lib/Key.tsx
+++ b/packages/keybr-lesson-ui/lib/Key.tsx
@@ -24,6 +24,7 @@ export const Key = ({
     confidence,
     isIncluded,
     isFocused,
+    isSecondFocused,
     isForced,
   } = lessonKey;
   return (
@@ -40,6 +41,7 @@ export const Key = ({
         isIncluded && confidence == null && styles.lessonKey_uncalibrated,
         isIncluded && isFocused && styles.lessonKey_focused,
         isIncluded && isForced && styles.lessonKey_forced,
+        isSecondFocused && styles.lessonKey_secondFocused,
         isSelectable && styles.lessonKey_selectable,
         isCurrent && styles.lessonKey_current,
       )}

--- a/packages/keybr-lesson-ui/lib/KeyLegend.test.tsx
+++ b/packages/keybr-lesson-ui/lib/KeyLegend.test.tsx
@@ -37,3 +37,21 @@ test("render included", () => {
 
   r.unmount();
 });
+
+test("render second focused", () => {
+  const r = render(
+    <FakeIntlProvider>
+      <KeyLegend
+        isIncluded={false}
+        confidence={null}
+        isFocused={false}
+        isForced={false}
+        isSecondFocused={true}
+      />
+    </FakeIntlProvider>,
+  );
+
+  isNotNull(r.container.querySelector(".lessonKey_secondFocused"));
+
+  r.unmount();
+});

--- a/packages/keybr-lesson-ui/lib/KeyLegend.tsx
+++ b/packages/keybr-lesson-ui/lib/KeyLegend.tsx
@@ -8,6 +8,7 @@ export const KeyLegend = ({
   isIncluded,
   isFocused,
   isForced,
+  isSecondFocused = false,
   size = "normal",
   title,
   ...props
@@ -16,6 +17,7 @@ export const KeyLegend = ({
   isIncluded: boolean;
   isFocused: boolean;
   isForced: boolean;
+  isSecondFocused?: boolean;
   size?: "normal" | "large";
   title?: string;
 } & MouseProps) => {
@@ -31,6 +33,7 @@ export const KeyLegend = ({
         isIncluded && confidence == null && styles.lessonKey_uncalibrated,
         isIncluded && isFocused && styles.lessonKey_focused,
         isIncluded && isForced && styles.lessonKey_forced,
+        isSecondFocused && styles.lessonKey_secondFocused,
       )}
       style={keyStyles(isIncluded ?? false, confidence ?? null)}
       title={title}

--- a/packages/keybr-lesson-ui/lib/KeyLegendList.tsx
+++ b/packages/keybr-lesson-ui/lib/KeyLegendList.tsx
@@ -54,6 +54,19 @@ export const KeyLegendList = () => {
       </li>
       <li>
         <KeyLegend //
+          isIncluded={false}
+          confidence={null}
+          isFocused={false}
+          isForced={false}
+          isSecondFocused={true}
+        />{" "}
+        <FormattedMessage
+          id="lesson.indicator.secondFocused"
+          defaultMessage="A locked key that will unlock next, or an already-included key that needs more practice, mixed into the lesson early as a preview."
+        />
+      </li>
+      <li>
+        <KeyLegend //
           isIncluded={true}
           confidence={null}
           isFocused={false}

--- a/packages/keybr-lesson-ui/lib/styles.module.less
+++ b/packages/keybr-lesson-ui/lib/styles.module.less
@@ -59,6 +59,10 @@
   text-decoration: underline;
 }
 
+.lessonKey_secondFocused {
+  outline: 1px solid var(--LessonKey--secondFocused__outline-color);
+}
+
 .lessonKey_selectable {
   cursor: pointer;
 }

--- a/packages/keybr-lesson/lib/confirmed-unlocks.ts
+++ b/packages/keybr-lesson/lib/confirmed-unlocks.ts
@@ -1,0 +1,45 @@
+import { type CodePoint } from "@keybr/unicode";
+
+const storageKey = "lesson.guided.confirmedUnlocks";
+
+// Local-only, like @keybr/settings's Preferences -- deliberately not a
+// Settings prop, since writing one reconstructs GuidedLesson itself.
+export class ConfirmedUnlocks {
+  static load(scope: string): ReadonlySet<CodePoint> {
+    return new Set(readAll()[scope] ?? []);
+  }
+
+  static confirm(scope: string, codePoint: CodePoint): void {
+    const all = readAll();
+    const scoped = new Set(all[scope] ?? []);
+    if (!scoped.has(codePoint)) {
+      scoped.add(codePoint);
+      writeAll({ ...all, [scope]: [...scoped] });
+    }
+  }
+}
+
+function readAll(): Record<string, readonly CodePoint[]> {
+  if (typeof window !== "object") {
+    return {};
+  }
+  const item = window.localStorage.getItem(storageKey);
+  if (item == null) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(item);
+    return parsed != null && typeof parsed === "object"
+      ? (parsed as Record<string, readonly CodePoint[]>)
+      : {};
+  } catch {
+    window.localStorage.removeItem(storageKey);
+    return {};
+  }
+}
+
+function writeAll(all: Record<string, readonly CodePoint[]>): void {
+  if (typeof window === "object") {
+    window.localStorage.setItem(storageKey, JSON.stringify(all));
+  }
+}

--- a/packages/keybr-lesson/lib/fakes.ts
+++ b/packages/keybr-lesson/lib/fakes.ts
@@ -1,8 +1,15 @@
 import { type Letter } from "@keybr/phonetic-model";
-import { type KeyStats, type KeyStatsMap, speedToTime } from "@keybr/result";
+import {
+  type KeySample,
+  type KeyStats,
+  type KeyStatsMap,
+  speedToTime,
+} from "@keybr/result";
 import { type Settings } from "@keybr/settings";
 import { type LessonKeys } from "./key.ts";
 import { Target } from "./target.ts";
+
+const defaultSampleCount = 5;
 
 export function fakeKeyStatsMap(
   settings: Settings,
@@ -10,11 +17,12 @@ export function fakeKeyStatsMap(
     letter: Letter,
     confidence: number | null,
     bestConfidence: number | null,
+    sampleCount?: number,
   ][],
 ): KeyStatsMap {
   const target = new Target(settings);
   const map = new Map<Letter, KeyStats>(
-    items.map(([letter, confidence, bestConfidence]) => {
+    items.map(([letter, confidence, bestConfidence, sampleCount]) => {
       const timeToType =
         confidence == null
           ? null
@@ -23,28 +31,54 @@ export function fakeKeyStatsMap(
         bestConfidence == null
           ? null
           : speedToTime(target.targetSpeed) / bestConfidence;
+      const count =
+        confidence == null && bestConfidence == null
+          ? 0
+          : (sampleCount ?? defaultSampleCount);
+      const samples: KeySample[] = Array.from(
+        { length: count },
+        (_, index) => ({
+          index,
+          timeStamp: 0,
+          hitCount: 1,
+          missCount: 0,
+          timeToType: timeToType ?? 0,
+          filteredTimeToType: timeToType ?? 0,
+        }),
+      );
       return [
         letter,
         {
           letter,
-          samples: [],
+          samples,
           timeToType,
           bestTimeToType,
         } as KeyStats,
       ];
     }),
   );
+  // A real KeyStatsMap.results grows by one per round; GuidedLesson.update()
+  // memoizes on it (plus identity of the last entry) to make its two
+  // same-round call sites idempotent. Synthesize one placeholder entry per
+  // sample so that varying sample counts across simulated rounds is seen
+  // as new evidence, while passing the exact same fakeKeyStatsMap() result
+  // to update() twice (same array, same last entry) is seen as a repeat.
+  const totalSamples = [...map.values()].reduce(
+    (sum, keyStats) => sum + keyStats.samples.length,
+    0,
+  );
+  const results = Array.from({ length: totalSamples }, () => ({}));
   return {
     letters: [...map.keys()],
-    results: [],
+    results,
     get: (letter) => map.get(letter),
     [Symbol.iterator]: () => map.values(),
   } as KeyStatsMap;
 }
 
 export function printLessonKeys(lessonKeys: LessonKeys) {
-  return lessonKeys
-    .findIncludedKeys()
+  return [...lessonKeys]
+    .filter((key) => key.isIncluded || key.isSecondFocused)
     .map((key) => {
       let s = `${key.letter}`;
       if (key.isForced) {
@@ -52,6 +86,9 @@ export function printLessonKeys(lessonKeys: LessonKeys) {
       }
       if (key.isFocused) {
         s = `[${s}]`;
+      }
+      if (key.isSecondFocused) {
+        s = `(${s})`;
       }
       return s;
     })

--- a/packages/keybr-lesson/lib/guided.test.ts
+++ b/packages/keybr-lesson/lib/guided.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, test } from "node:test";
 import { Layout, loadKeyboard } from "@keybr/keyboard";
-import { FakePhoneticModel } from "@keybr/phonetic-model";
+import { FakePhoneticModel, type Letter } from "@keybr/phonetic-model";
 import { makeKeyStatsMap } from "@keybr/result";
 import { Settings } from "@keybr/settings";
-import { deepEqual, equal } from "rich-assert";
+import { deepEqual, doesNotInclude, equal, includes, ok } from "rich-assert";
 import { fakeKeyStatsMap, printLessonKeys } from "./fakes.ts";
 import { GuidedLesson } from "./guided.ts";
 import { LessonKey } from "./key.ts";
@@ -243,6 +243,770 @@ test("generate text with natural words", () => {
     "abcaf abcbe abcaa abcaf abcbe abcaa abcaf abcbe abcaa abcaf abcbe abcaa " +
       "abcaf abcbe abcaa abcaf abcbe abcaa abcaf abcbe",
   );
+});
+
+describe("train second key", () => {
+  const keyboard = loadKeyboard(Layout.EN_US);
+  const {
+    letter1, // A
+    letter2, // B - weakest, focused
+    letter3, // C
+    letter4, // D
+    letter5, // E - second-weakest, or already attempted and trailing
+    letter6, // F
+    letter7, // G - the next locked letter
+    letter8, // H
+    letter9, // I
+    letter10, // J
+  } = FakePhoneticModel;
+
+  describe("while a letter remains locked", () => {
+    // The focused key's words are built only from a, b, c, d, e, f, and the
+    // next locked letter's words also contain g, so the two sets can be
+    // told apart with a simple substring check.
+    const mainWords = [
+      "abcdea",
+      "abcdeb",
+      "abcdec",
+      "abcdfa",
+      "abcdfb",
+      "abcdfc",
+      "abcdaa",
+      "abcdab",
+      "abcdac",
+      "abcdad",
+      "abcdae",
+      "abcdaf",
+      "abcdba",
+      "abcdbb",
+      "abcdbc",
+    ];
+    const nextWords = [
+      "efgab",
+      "efgac",
+      "efgad",
+      "efgae",
+      "efgaf",
+      "efgba",
+      "efgbb",
+      "efgbc",
+      "efgbd",
+      "efgbe",
+      "efgca",
+      "efgcb",
+      "efgcc",
+      "efgcd",
+      "efgce",
+    ];
+
+    function setup(trainSecondKey: boolean) {
+      const settings = new Settings()
+        .set(lessonProps.guided.naturalWords, true)
+        .set(lessonProps.guided.trainSecondKey, trainSecondKey);
+      const model = new FakePhoneticModel();
+      const lesson = new GuidedLesson(settings, keyboard, model, [
+        ...mainWords,
+        ...nextWords,
+      ]);
+      const lessonKeys = lesson.update(makeKeyStatsMap(lesson.letters, []));
+      return { lesson, lessonKeys, model };
+    }
+
+    it("does not preview the next locked letter when disabled", () => {
+      const { lesson, lessonKeys, model } = setup(false);
+
+      equal(printLessonKeys(lessonKeys), "[A]BCDEF");
+      doesNotInclude(lesson.generate(lessonKeys, model.rng), "efg");
+    });
+
+    it("previews the next locked letter when enabled", () => {
+      const { lesson, lessonKeys, model } = setup(true);
+
+      equal(printLessonKeys(lessonKeys), "[A]BCDEF(G)");
+      includes(lesson.generate(lessonKeys, model.rng), "efg");
+    });
+  });
+
+  describe("once all letters are unlocked", () => {
+    // The focused key's words are built only from a, b, c, d, and the
+    // second-weakest key's words are built only from e, f, g, h, so the two
+    // sets can be told apart with a simple substring check.
+    const mainWords = [
+      "abcd",
+      "abdc",
+      "acbd",
+      "acdb",
+      "adbc",
+      "adcb",
+      "bacd",
+      "badc",
+      "bcad",
+      "bcda",
+      "bdac",
+      "bdca",
+      "cabd",
+      "cadb",
+      "cbad",
+    ];
+    const secondWeakestWords = [
+      "efgh",
+      "efhg",
+      "egfh",
+      "eghf",
+      "ehfg",
+      "ehgf",
+      "fegh",
+      "fehg",
+      "fgeh",
+      "fghe",
+      "fheg",
+      "fhge",
+      "gefh",
+      "gehf",
+      "gfeh",
+    ];
+
+    function setup(
+      trainSecondKey: boolean,
+      confidences: readonly [letter: LessonKey["letter"], confidence: number][],
+    ) {
+      const settings = new Settings()
+        .set(lessonProps.guided.naturalWords, true)
+        .set(lessonProps.guided.alphabetSize, 1) // all letters already unlocked
+        .set(lessonProps.guided.trainSecondKey, trainSecondKey);
+      const model = new FakePhoneticModel();
+      const lesson = new GuidedLesson(settings, keyboard, model, [
+        ...mainWords,
+        ...secondWeakestWords,
+      ]);
+      const lessonKeys = lesson.update(
+        fakeKeyStatsMap(
+          settings,
+          confidences.map(([letter, confidence]) => [
+            letter,
+            confidence,
+            confidence,
+          ]),
+        ),
+      );
+      return { lesson, lessonKeys, model };
+    }
+
+    // B is the weakest key and E is the second-weakest; everyone else is
+    // already above the target speed.
+    const bWeakestEsecondWeakest: [LessonKey["letter"], number][] = [
+      [letter1, 1],
+      [letter2, 0.5],
+      [letter3, 1],
+      [letter4, 1],
+      [letter5, 0.7],
+      [letter6, 1],
+      [letter7, 1],
+      [letter8, 1],
+      [letter9, 1],
+      [letter10, 1],
+    ];
+
+    it("does not mark or mix in the second-weakest key when disabled", () => {
+      const { lesson, lessonKeys, model } = setup(
+        false,
+        bWeakestEsecondWeakest,
+      );
+
+      equal(printLessonKeys(lessonKeys), "A[B]CDEF!G!H!I!J");
+      doesNotInclude(lesson.generate(lessonKeys, model.rng), "e");
+    });
+
+    it("marks and mixes in the second-weakest key when enabled", () => {
+      const { lesson, lessonKeys, model } = setup(true, bWeakestEsecondWeakest);
+
+      equal(printLessonKeys(lessonKeys), "A[B]CD(E)F!G!H!I!J");
+      includes(lesson.generate(lessonKeys, model.rng), "e");
+    });
+
+    it("has no effect when there is no second key below the target speed", () => {
+      const { lesson, lessonKeys, model } = setup(true, [
+        [letter1, 1],
+        [letter2, 0.5], // the only key below the target speed
+        [letter3, 1],
+        [letter4, 1],
+        [letter5, 1],
+        [letter6, 1],
+        [letter7, 1],
+        [letter8, 1],
+        [letter9, 1],
+        [letter10, 1],
+      ]);
+
+      equal(printLessonKeys(lessonKeys), "A[B]CDEF!G!H!I!J");
+      doesNotInclude(lesson.generate(lessonKeys, model.rng), "e");
+    });
+  });
+
+  it("prefers an untested next locked letter over an already-attempted trailing key", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // G has never been previewed at all, which is exactly when preview is
+    // most valuable, so it wins the slot even over an already-attempted
+    // trailing key.
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.5, 0.5],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 0.7, 0.7],
+        [letter6, 1, 1],
+        [letter7, null, null],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(lessonKeys), "A[B]CDEF(G)");
+  });
+
+  it("lets well-evidenced letters recover past a stalled earlier key, except nextKey itself", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // B (already included) hasn't taken its turn yet. G is nextKey -- its
+    // own evidence might be nothing but thin preview reps, so it still has
+    // to wait, previewed but locked. H and J have real, independent
+    // evidence (e.g. recovered after a page reload, or mastered elsewhere)
+    // and recover regardless of B's stall. I stays locked on its own
+    // merits -- it's genuinely not yet confident.
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.5, 0.5],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, 1, 1],
+        [letter8, 1, 1],
+        [letter9, 0.6, 0.6],
+        [letter10, 1, 1],
+      ]),
+    );
+
+    equal(printLessonKeys(lessonKeys), "A[B]CDEF(G)HJ");
+    ok(lessonKeys.find(letter7.codePoint)?.isIncluded === false);
+    ok(lessonKeys.find(letter8.codePoint)?.isIncluded === true);
+    ok(lessonKeys.find(letter9.codePoint)?.isIncluded === false);
+    ok(lessonKeys.find(letter10.codePoint)?.isIncluded === true);
+  });
+
+  it("rotates the second focus as a preview improves past a trailing key", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // E is trailing but nearly caught up (0.9), while G -- previewed as
+    // the next locked letter -- is doing worse (0.3), so G should win the
+    // second-focus slot instead of E.
+    const struggling = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.5, 0.5],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 0.9, 0.9],
+        [letter6, 1, 1],
+        [letter7, 0.3, 0.3],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(struggling), "A[B]CDEF(G)");
+    ok(struggling.find(letter7.codePoint)?.isIncluded === false);
+
+    // G's preview reps have since improved past E, so the second focus
+    // rotates to E, the now-weaker key, without unlocking G.
+    const improved = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.5, 0.5],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 0.9, 0.9],
+        [letter6, 1, 1],
+        [letter7, 0.95, 0.95],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(improved), "A[B]CD(E)F");
+    ok(improved.find(letter7.codePoint)?.isIncluded === false);
+  });
+
+  it("keeps the trailing key ahead of the preview on a confidence tie", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // E (trailing) and G (previewed) are tied at 0.6; the trailing key
+    // should keep the second-focus slot on a tie, not the preview.
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.4, 0.4],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 0.6, 0.6],
+        [letter6, 1, 1],
+        [letter7, 0.6, 0.6],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(lessonKeys), "A[B]CD(E)F");
+    ok(lessonKeys.find(letter7.codePoint)?.isIncluded === false);
+  });
+
+  it("skips a stale live confidence left by recoverKeys when picking the second key", () => {
+    const settings = new Settings()
+      .set(lessonProps.guided.trainSecondKey, true)
+      .set(lessonProps.guided.recoverKeys, true);
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // With recovery on, second-key selection reads live confidence. Both
+    // B and E have null live confidence (no recent samples, despite once
+    // being mastered); B still becomes the primary focus (null counts as
+    // the weakest), but E must not win the second slot for the same
+    // reason. G, the untested next-in-line letter, outranks F (a real but
+    // weaker trailing candidate) for the same reason it always does.
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, null, 1],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, null, 1],
+        [letter6, 0.8, 1],
+        [letter7, null, null],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(lessonKeys), "A[B]CDEF(G)");
+  });
+
+  it("unlocks the previewed letter on schedule regardless of how its preview reps went", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // G has done poorly in preview (0.1), but per the PR description,
+    // preview samples are never factored into unlocking it either way:
+    // now that every previously-included key is above target, it's
+    // simply G's turn.
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 1, 1],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, 0.1, 0.1],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(lessonKeys), "ABCDEF[G](H)");
+  });
+
+  it("still gives a fast typer's newly-previewed letter its own turn instead of unlocking it on one sample", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // G is already fully confident (a fast typer can clear target speed
+    // on the very first preview rep), but it still has to spend the one
+    // new-unlock slot for this call like anyone else -- H hasn't been
+    // previewed at all yet, so it stays locked. With every included key
+    // now at confidence >= 1, G (the newest) is the fallback focus rather
+    // than going dark.
+    const first = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 1, 1],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, 1, 1],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+    ok(first.find(letter7.codePoint)?.isIncluded === true);
+    ok(first.find(letter8.codePoint)?.isIncluded === false);
+    equal(printLessonKeys(first), "ABCDEF[G](H)");
+
+    // Next call: H is now nextKey and, on its very first preview rep, is
+    // already confident too -- but on a single sample that's not yet real
+    // evidence, so it still has to win its own honest turn, not sneak in
+    // on a thin preview reading. It does, because the chain (now including
+    // G) is confident.
+    const second = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 1, 1],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, 1, 1],
+        [letter8, 1, 1, 1],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+    ok(second.find(letter7.codePoint)?.isIncluded === true);
+    ok(second.find(letter8.codePoint)?.isIncluded === true);
+    ok(second.find(letter9.codePoint)?.isIncluded === false);
+    equal(printLessonKeys(second), "ABCDEFG[H](I)");
+  });
+
+  it("still unlocks an already-mastered next letter when the setting is off, but not one with too few samples", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      false,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // With the setting off, G can only have gotten this confident from
+    // some other lesson type, never from a preview, so it's safe to
+    // unlock it right away like any other already-mastered key. H looks
+    // just as confident, but on only 2 samples -- a single lucky rep
+    // shouldn't be enough to count as mastery, so it must stay locked.
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.5, 0.5],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, 1, 1],
+        [letter8, 1, 1, 2],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(lessonKeys), "A[B]CDEFG");
+    ok(lessonKeys.find(letter8.codePoint)?.isIncluded === false);
+  });
+
+  it("keeps nextKey locked no matter how much preview evidence it earns, while letting evidenced letters past it recover", () => {
+    const settings = new Settings()
+      .set(lessonProps.guided.naturalWords, false)
+      .set(lessonProps.guided.trainSecondKey, true);
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // While G remains locked, it is the one mixed in as the second key.
+    const locked = lesson.update(makeKeyStatsMap(lesson.letters, []));
+
+    equal(printLessonKeys(locked), "[A]BCDEF(G)");
+
+    // G now has plenty of real preview samples, but that's nextKey's own
+    // evidence, which never counts -- it stays locked regardless. B and E
+    // are both still weak (E wins the second slot as the weaker trailing
+    // key). H, I, and J have real, independent evidence and recover
+    // despite G still being locked ahead of them.
+    const unlocked = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.5, 0.5],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 0.7, 0.7],
+        [letter6, 1, 1],
+        [letter7, 1, 1],
+        [letter8, 1, 1],
+        [letter9, 1, 1],
+        [letter10, 1, 1],
+      ]),
+    );
+
+    equal(printLessonKeys(unlocked), "A[B]CD(E)FHIJ");
+    ok(unlocked.find(letter7.codePoint)?.isIncluded === false);
+    ok(unlocked.find(letter8.codePoint)?.isIncluded === true);
+    ok(unlocked.find(letter9.codePoint)?.isIncluded === true);
+    ok(unlocked.find(letter10.codePoint)?.isIncluded === true);
+  });
+
+  it("lets a forced key compete for the second slot without blocking the true next-in-line letter", () => {
+    const settings = new Settings()
+      .set(lessonProps.guided.alphabetSize, 0.5) // forces G and H included
+      .set(lessonProps.guided.trainSecondKey, true);
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    // G and H are forced included despite no real progress. G, untested,
+    // becomes the primary focus. I -- the true next-in-line locked letter
+    // -- still wins the second slot over H, a forced trailing key with
+    // real (if weak) data.
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 1, 1],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, null, null],
+        [letter8, 0.4, 0.4],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+
+    equal(printLessonKeys(lessonKeys), "ABCDEF[!G]!H(I)");
+  });
+
+  it("reaches every letter across repeated rounds without freezing", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    let lessonKeys = lesson.update(makeKeyStatsMap(lesson.letters, []));
+    for (
+      let round = 0;
+      round < 20 && lessonKeys.findExcludedKeys().length > 0;
+      round++
+    ) {
+      lessonKeys = lesson.update(
+        fakeKeyStatsMap(
+          settings,
+          [...lessonKeys].map((key) => {
+            const mastered = key.isIncluded || key.isSecondFocused;
+            return [key.letter, mastered ? 1 : null, mastered ? 1 : null];
+          }),
+        ),
+      );
+    }
+
+    equal(lessonKeys.findExcludedKeys().length, 0);
+
+    // The last letter to unlock has had zero practice yet, so it's
+    // correctly the focus for this round. One more round of "practicing"
+    // it should clear focus entirely, with nothing left to work on.
+    lessonKeys = lesson.update(
+      fakeKeyStatsMap(
+        settings,
+        [...lessonKeys].map((key) => [key.letter, 1, 1]),
+      ),
+    );
+    ok(lessonKeys.findFocusedKey() == null);
+  });
+
+  it("never unlocks two never-before-included keys in the same call, even across a long stall with preview rotation", () => {
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+    const stalled = letter3; // C: never earns real progress until round 8.
+
+    const state = new Map<
+      Letter,
+      { samples: number; bestConfidence: number | null }
+    >();
+    for (const letter of lesson.letters) {
+      state.set(letter, { samples: 0, bestConfidence: null });
+    }
+    const snapshot = (): [Letter, number | null, number | null, number][] =>
+      [...state].map(([letter, s]) => [
+        letter,
+        s.bestConfidence,
+        s.bestConfidence,
+        s.samples,
+      ]);
+
+    let lessonKeys = lesson.update(fakeKeyStatsMap(settings, snapshot()));
+    let previouslyIncluded = new Set(
+      lessonKeys.findIncludedKeys().map((key) => key.letter),
+    );
+
+    for (let round = 0; round < 15; round++) {
+      for (const key of lessonKeys) {
+        if (key.letter === stalled && round < 8) {
+          continue;
+        }
+        if (key.isIncluded || key.isSecondFocused) {
+          const s = state.get(key.letter)!;
+          s.samples += 1;
+          s.bestConfidence = 1;
+        }
+      }
+
+      lessonKeys = lesson.update(fakeKeyStatsMap(settings, snapshot()));
+
+      // While C is stalled, the preview must stay pinned on the true
+      // next-in-line letter (never dark, never a second locked letter).
+      if (round < 8) {
+        equal(lessonKeys.findFocusedKey()?.letter, stalled);
+        ok(lessonKeys.findSecondFocusedKey() != null);
+      }
+
+      // At most one never-before-included key may unlock per call, whether
+      // via the turn-based path or already graduated from preview reps --
+      // a second one, graduated or not, must wait for its own turn.
+      const newlyIncluded = lessonKeys
+        .findIncludedKeys()
+        .filter((key) => !previouslyIncluded.has(key.letter));
+      ok(newlyIncluded.length <= 1);
+
+      previouslyIncluded = new Set(
+        lessonKeys.findIncludedKeys().map((key) => key.letter),
+      );
+    }
+
+    equal(lessonKeys.findExcludedKeys().length, 0);
+  });
+
+  it("is idempotent across repeat calls with the same evidence, as the UI layer actually does per round", () => {
+    // page-practice calls update() twice per round on the same
+    // GuidedLesson instance: once from LetterEvents (to detect the unlock
+    // toast) and once from a freshly-constructed LessonState (to build the
+    // next round's lessonKeys) -- both against identical keyStatsMap
+    // evidence. The second call must return the same result, not spend a
+    // second turn-based unlock against the first call's now-mutated
+    // #confirmedUnlocks.
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    const stats = fakeKeyStatsMap(settings, [
+      [letter1, 1, 1],
+      [letter2, 1, 1],
+      [letter3, 1, 1],
+      [letter4, 1, 1],
+      [letter5, 1, 1],
+      [letter6, 1, 1],
+      [letter7, null, null],
+      [letter8, null, null],
+      [letter9, null, null],
+      [letter10, null, null],
+    ]);
+
+    const first = lesson.update(stats);
+    const second = lesson.update(stats);
+
+    equal(second, first);
+    equal(printLessonKeys(second), "ABCDEF[G](H)");
+    ok(second.find(letter8.codePoint)?.isIncluded === false);
+
+    // A genuinely new round (different evidence) still unlocks the next
+    // letter normally -- the cache doesn't get stuck.
+    const third = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 1, 1],
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, 1, 1],
+        [letter8, null, null],
+        [letter9, null, null],
+        [letter10, null, null],
+      ]),
+    );
+    ok(third.find(letter8.codePoint)?.isIncluded === true);
+  });
+
+  it("recovers already-earned unlocks instantly on a brand new instance, even behind a currently-stalled key", () => {
+    // A fresh GuidedLesson (e.g. after a page reload, or any settings
+    // change that reconstructs it) has no memory of past calls. It must
+    // still recognize letters with real accumulated evidence as unlocked
+    // immediately, not re-derive them one per call -- and a stalled key
+    // must not hold hostage letters that already have their own evidence.
+    const settings = new Settings().set(
+      lessonProps.guided.trainSecondKey,
+      true,
+    );
+    const model = new FakePhoneticModel();
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+
+    const lessonKeys = lesson.update(
+      fakeKeyStatsMap(settings, [
+        [letter1, 1, 1],
+        [letter2, 0.5, 0.5], // stalled, never took its turn
+        [letter3, 1, 1],
+        [letter4, 1, 1],
+        [letter5, 1, 1],
+        [letter6, 1, 1],
+        [letter7, 1, 1],
+        [letter8, 1, 1],
+        [letter9, 1, 1],
+        [letter10, 1, 1],
+      ]),
+    );
+
+    ok(lessonKeys.find(letter8.codePoint)?.isIncluded === true);
+    ok(lessonKeys.find(letter9.codePoint)?.isIncluded === true);
+    ok(lessonKeys.find(letter10.codePoint)?.isIncluded === true);
+  });
+
+  it("does not crash when naturalWords is disabled", () => {
+    const settings = new Settings()
+      .set(lessonProps.guided.naturalWords, false)
+      .set(lessonProps.guided.trainSecondKey, true);
+    const model = new FakePhoneticModel(["uno", "due", "tre"]);
+    const lesson = new GuidedLesson(settings, keyboard, model, []);
+    const lessonKeys = lesson.update(makeKeyStatsMap(lesson.letters, []));
+
+    ok(lesson.generate(lessonKeys, model.rng).length > 0);
+  });
 });
 
 describe("unlock keys", () => {

--- a/packages/keybr-lesson/lib/guided.ts
+++ b/packages/keybr-lesson/lib/guided.ts
@@ -2,8 +2,10 @@ import { type WordList } from "@keybr/content";
 import { type Keyboard } from "@keybr/keyboard";
 import { Filter, Letter, type PhoneticModel } from "@keybr/phonetic-model";
 import { type RNGStream } from "@keybr/rand";
-import { type KeyStatsMap } from "@keybr/result";
+import { type KeyStatsMap, type Result } from "@keybr/result";
 import { type Settings } from "@keybr/settings";
+import { type CodePoint } from "@keybr/unicode";
+import { ConfirmedUnlocks } from "./confirmed-unlocks.ts";
 import { Dictionary, filterWordList } from "./dictionary.ts";
 import { LessonKey, LessonKeys } from "./key.ts";
 import { Lesson } from "./lesson.ts";
@@ -11,14 +13,42 @@ import { lessonProps } from "./settings.ts";
 import { Target } from "./target.ts";
 import { generateFragment } from "./text/fragment.ts";
 import {
+  interleavedWords,
   mangledWords,
   phoneticWords,
   randomWords,
   uniqueWords,
 } from "./text/words.ts";
 
+const secondKeyWordProbability = 0.2;
+// Minimum samples for a trailing included key to win the second-focus slot, and for a
+// locked key with bestConfidence >= 1 to unlock out of order (nextKey itself is exempt).
+const minSecondKeySamples = 3;
+
+function rawConfidenceOf(key: LessonKey, recoverKeys: boolean): number | null {
+  return recoverKeys ? key.confidence : key.bestConfidence;
+}
+
+function confidenceOf(key: LessonKey, recoverKeys: boolean): number {
+  return rawConfidenceOf(key, recoverKeys) ?? 0;
+}
+
 export class GuidedLesson extends Lesson {
   readonly dictionary: Dictionary;
+  // Cache of letters already known settled, so a reaffirm never re-spends
+  // the turn slot. Seeded from and written through to ConfirmedUnlocks, so
+  // a settings change or reload never re-locks an already-unlocked letter.
+  readonly #confirmedUnlocks: Set<CodePoint>;
+  readonly #confirmedUnlocksScope: string;
+  // update() runs twice per round from different call sites (once for the
+  // unlock toast, once for the next round's lessonKeys) against the same
+  // evidence. Memoized on the last Result seen, so the second call is a
+  // true no-op returning the first call's LessonKeys, rather than
+  // re-deriving unlocks from a #confirmedUnlocks that the first call may
+  // have already mutated.
+  #lastResult: Result | undefined = undefined;
+  #lastResultsCount = -1;
+  #lastLessonKeys: LessonKeys | null = null;
 
   constructor(
     settings: Settings,
@@ -32,6 +62,10 @@ export class GuidedLesson extends Lesson {
         (word) => word.length > 2,
       ),
     );
+    this.#confirmedUnlocksScope = keyboard.layout.id;
+    this.#confirmedUnlocks = new Set(
+      ConfirmedUnlocks.load(this.#confirmedUnlocksScope),
+    );
   }
 
   override get letters() {
@@ -39,8 +73,24 @@ export class GuidedLesson extends Lesson {
   }
 
   override update(keyStatsMap: KeyStatsMap) {
+    const { results } = keyStatsMap;
+    const lastResult = results.at(-1);
+    if (
+      this.#lastLessonKeys != null &&
+      results.length === this.#lastResultsCount &&
+      lastResult === this.#lastResult
+    ) {
+      // Same evidence as the last call (the other of this round's two
+      // call sites) -- return the same LessonKeys rather than re-deriving
+      // unlocks against a #confirmedUnlocks this call may have mutated.
+      return this.#lastLessonKeys;
+    }
+    this.#lastResultsCount = results.length;
+    this.#lastResult = lastResult;
+
     const alphabetSize = this.settings.get(lessonProps.guided.alphabetSize);
     const recoverKeys = this.settings.get(lessonProps.guided.recoverKeys);
+    const trainSecondKey = this.settings.get(lessonProps.guided.trainSecondKey);
 
     const letters = this.#getLetters();
 
@@ -53,6 +103,15 @@ export class GuidedLesson extends Lesson {
     const lessonKeys = new LessonKeys(
       letters.map((letter) => LessonKey.from(keyStatsMap.get(letter), target)),
     );
+
+    // Caps the turn-based unlock below to one letter per call.
+    let unlockedThisTurn = false;
+    // Among letters not already confirmed below, the first one reached is
+    // nextKey, the one letter currently being previewed.
+    let nextKeyResolved = false;
+    // Unlike unlockedThisTurn, not set by masteredElsewhere below -- several
+    // already-evidenced keys may still unlock together in one call.
+    let turnBasedUnlock = false;
 
     for (const lessonKey of lessonKeys) {
       const includedKeys = lessonKeys.findIncludedKeys();
@@ -69,50 +128,136 @@ export class GuidedLesson extends Lesson {
         continue;
       }
 
-      if ((lessonKey.bestConfidence ?? 0) >= 1) {
-        // Must include all confident keys.
+      if (this.#confirmedUnlocks.has(lessonKey.letter.codePoint)) {
+        // Already settled, even if trainSecondKey is off now -- once
+        // confirmed, always reaffirmed for free.
         lessonKeys.include(lessonKey.letter);
         continue;
       }
 
-      if (recoverKeys) {
-        if (includedKeys.every((key) => (key.confidence ?? 0) >= 1)) {
-          // Include a new key only when all the previous keys
-          // are now above the target speed.
+      if (trainSecondKey && !nextKeyResolved) {
+        // nextKey must win its own turn-based turn -- its evidence may be
+        // nothing but thin preview reps, so it never gets the shortcut below.
+        nextKeyResolved = true;
+        if (
+          !unlockedThisTurn &&
+          includedKeys.every((key) => confidenceOf(key, recoverKeys) >= 1)
+        ) {
           lessonKeys.include(lessonKey.letter);
-          continue;
+          this.#confirmUnlock(lessonKey.letter.codePoint);
+          unlockedThisTurn = true;
+          turnBasedUnlock = true;
         }
-      } else {
-        if (includedKeys.every((key) => (key.bestConfidence ?? 0) >= 1)) {
-          // Include a new key only when all the previous keys
-          // were once above the target speed.
-          lessonKeys.include(lessonKey.letter);
-          continue;
+        continue;
+      }
+
+      // Require a few samples so a single lucky rep can't pass as mastery.
+      // Not itself set by masteredElsewhere -- several already-evidenced
+      // keys may still unlock together, just not alongside a turn-based one.
+      const masteredElsewhere =
+        !turnBasedUnlock &&
+        (lessonKey.bestConfidence ?? 0) >= 1 &&
+        lessonKey.samples.length >= minSecondKeySamples;
+      if (masteredElsewhere) {
+        // Confident keys unlock regardless of order (e.g. mastered in
+        // another lesson type, or recovered from before this instance
+        // existed).
+        lessonKeys.include(lessonKey.letter);
+        if (trainSecondKey) {
+          this.#confirmUnlock(lessonKey.letter.codePoint);
         }
+        continue;
+      }
+
+      if (
+        !trainSecondKey &&
+        !unlockedThisTurn &&
+        includedKeys.every((key) => confidenceOf(key, recoverKeys) >= 1)
+      ) {
+        // Include the next key once all previous ones clear the target
+        // speed. A key reaching here failed masteredElsewhere above
+        // (bestConfidence < 1, or too few samples).
+        lessonKeys.include(lessonKey.letter);
+        unlockedThisTurn = true;
+        continue;
       }
     }
 
     // Find the least confident of all included keys and focus on it.
-    const confidenceOf = (key: LessonKey): number => {
-      return recoverKeys ? (key.confidence ?? 0) : (key.bestConfidence ?? 0);
-    };
+    const excludedKeys = lessonKeys.findExcludedKeys();
     const weakestKeys = lessonKeys
       .findIncludedKeys()
-      .filter((key) => confidenceOf(key) < 1)
-      .sort((a, b) => confidenceOf(a) - confidenceOf(b));
-    if (weakestKeys.length > 0) {
-      lessonKeys.focus(weakestKeys[0].letter);
+      .filter((key) => confidenceOf(key, recoverKeys) < 1)
+      .sort(
+        (a, b) => confidenceOf(a, recoverKeys) - confidenceOf(b, recoverKeys),
+      );
+    // Under trainSecondKey, a key can unlock already calibrated (preview
+    // reps pushed its bestConfidence to 1 before it won its turn), leaving
+    // no key under the target speed -- fall back to the most recently
+    // unlocked key rather than going dark while letters remain locked.
+    const focusedKey =
+      weakestKeys[0] ??
+      (excludedKeys.length > 0
+        ? (lessonKeys.findIncludedKeys().at(-1) ?? null)
+        : null);
+    if (focusedKey != null) {
+      lessonKeys.focus(focusedKey.letter);
     }
 
+    // Optionally focus a second key too: the least confident of the
+    // trailing included keys and the next locked letter (previewed).
+    if (trainSecondKey) {
+      // Only the true next-in-line letter is ever previewed; a deeper locked letter never competes.
+      const [nextKey] = excludedKeys;
+      const nextKeyGraduated =
+        nextKey != null && confidenceOf(nextKey, recoverKeys) >= 1;
+      const candidates = weakestKeys
+        .filter((key) => key !== focusedKey)
+        .filter((key) => rawConfidenceOf(key, recoverKeys) != null);
+      // nextKey competes even with no samples yet, so it isn't outranked by
+      // a trailing key just because it hasn't been previewed at all.
+      if (nextKey != null && !nextKeyGraduated) {
+        candidates.push(nextKey);
+      }
+      const secondKeyCandidates = candidates
+        .filter(
+          (key) => key === nextKey || key.samples.length >= minSecondKeySamples,
+        )
+        .sort(
+          (a, b) => confidenceOf(a, recoverKeys) - confidenceOf(b, recoverKeys),
+        );
+      // Falls back to nextKey if graduated and nothing else needs the slot, so it's never dark.
+      const secondKey = secondKeyCandidates[0] ?? nextKey ?? null;
+      if (secondKey != null) {
+        lessonKeys.focusSecond(secondKey.letter);
+      }
+    }
+
+    this.#lastLessonKeys = lessonKeys;
     return lessonKeys;
   }
 
   override generate(lessonKeys: LessonKeys, rng: RNGStream) {
-    const filter = new Filter(
-      lessonKeys.findIncludedKeys(),
-      lessonKeys.findFocusedKey(),
-    );
-    const wordGenerator = this.#makeWordGenerator(filter, rng);
+    const includedKeys = lessonKeys.findIncludedKeys();
+    const filter = new Filter(includedKeys, lessonKeys.findFocusedKey());
+    let wordGenerator = this.#makeWordGenerator(filter, rng);
+    const secondFocusedKey = lessonKeys.findSecondFocusedKey();
+    if (secondFocusedKey != null) {
+      const secondFilter = new Filter(
+        // A still-locked second key must be added; Filter requires the
+        // focused letter to be present.
+        secondFocusedKey.isIncluded
+          ? includedKeys
+          : [...includedKeys, secondFocusedKey],
+        secondFocusedKey,
+      );
+      wordGenerator = interleavedWords(
+        wordGenerator,
+        this.#makeWordGenerator(secondFilter, rng),
+        secondKeyWordProbability,
+        rng,
+      );
+    }
     const words = mangledWords(
       uniqueWords(wordGenerator),
       this.model.language,
@@ -126,6 +271,11 @@ export class GuidedLesson extends Lesson {
     return generateFragment(this.settings, words, {
       repeatWords: this.settings.get(lessonProps.repeatWords),
     });
+  }
+
+  #confirmUnlock(codePoint: CodePoint) {
+    this.#confirmedUnlocks.add(codePoint);
+    ConfirmedUnlocks.confirm(this.#confirmedUnlocksScope, codePoint);
   }
 
   #getLetters() {

--- a/packages/keybr-lesson/lib/key.test.ts
+++ b/packages/keybr-lesson/lib/key.test.ts
@@ -132,3 +132,109 @@ test("mutate lesson keys", () => {
     }),
   );
 });
+
+test("mutate lesson keys, second focus", () => {
+  // Arrange.
+
+  const keys = new LessonKeys([
+    new LessonKey({
+      letter: letter1,
+      samples: [],
+      timeToType: 300,
+      bestTimeToType: 300,
+      confidence: 1.0,
+      bestConfidence: 1.0,
+    }),
+    new LessonKey({
+      letter: letter2,
+      samples: [],
+      timeToType: 300,
+      bestTimeToType: 300,
+      confidence: 1.0,
+      bestConfidence: 1.0,
+    }),
+  ]);
+
+  // Act.
+
+  keys.focus(letter1);
+  keys.focusSecond(letter2);
+
+  // Assert.
+
+  deepEqual(
+    keys.findFocusedKey(),
+    new LessonKey({
+      letter: letter1,
+      samples: [],
+      timeToType: 300,
+      bestTimeToType: 300,
+      confidence: 1.0,
+      bestConfidence: 1.0,
+      isIncluded: true,
+      isForced: false,
+      isFocused: true,
+    }),
+  );
+  deepEqual(
+    keys.findSecondFocusedKey(),
+    new LessonKey({
+      letter: letter2,
+      samples: [],
+      timeToType: 300,
+      bestTimeToType: 300,
+      confidence: 1.0,
+      bestConfidence: 1.0,
+      isIncluded: false,
+      isForced: false,
+      isSecondFocused: true,
+    }),
+  );
+});
+
+test("mutate lesson keys, second focus on an already-included key", () => {
+  // Arrange.
+
+  const keys = new LessonKeys([
+    new LessonKey({
+      letter: letter1,
+      samples: [],
+      timeToType: 300,
+      bestTimeToType: 300,
+      confidence: 1.0,
+      bestConfidence: 1.0,
+    }),
+    new LessonKey({
+      letter: letter2,
+      samples: [],
+      timeToType: 300,
+      bestTimeToType: 300,
+      confidence: 1.0,
+      bestConfidence: 1.0,
+    }),
+  ]);
+
+  // Act.
+
+  keys.include(letter1);
+  keys.include(letter2);
+  keys.focus(letter1);
+  keys.focusSecond(letter2);
+
+  // Assert.
+
+  deepEqual(
+    keys.findSecondFocusedKey(),
+    new LessonKey({
+      letter: letter2,
+      samples: [],
+      timeToType: 300,
+      bestTimeToType: 300,
+      confidence: 1.0,
+      bestConfidence: 1.0,
+      isIncluded: true,
+      isForced: false,
+      isSecondFocused: true,
+    }),
+  );
+});

--- a/packages/keybr-lesson/lib/key.ts
+++ b/packages/keybr-lesson/lib/key.ts
@@ -24,6 +24,7 @@ export class LessonKey implements KeyStats {
   readonly bestConfidence: number | null;
   readonly isIncluded: boolean;
   readonly isFocused: boolean;
+  readonly isSecondFocused: boolean;
   readonly isForced: boolean;
 
   constructor({
@@ -35,6 +36,7 @@ export class LessonKey implements KeyStats {
     bestConfidence,
     isIncluded = false,
     isFocused = false,
+    isSecondFocused = false,
     isForced = false,
   }: {
     letter: Letter;
@@ -45,6 +47,7 @@ export class LessonKey implements KeyStats {
     bestConfidence: number | null;
     isIncluded?: boolean;
     isFocused?: boolean;
+    isSecondFocused?: boolean;
     isForced?: boolean;
   }) {
     this.letter = letter;
@@ -55,6 +58,7 @@ export class LessonKey implements KeyStats {
     this.bestConfidence = bestConfidence;
     this.isIncluded = isIncluded;
     this.isFocused = isFocused;
+    this.isSecondFocused = isSecondFocused;
     this.isForced = isForced;
     Object.freeze(this);
   }
@@ -71,6 +75,7 @@ export class LessonKey implements KeyStats {
       ...this,
       isIncluded: false,
       isFocused: false,
+      isSecondFocused: false,
       isForced: false,
     });
   }
@@ -88,6 +93,13 @@ export class LessonKey implements KeyStats {
       ...this,
       isIncluded: true,
       isFocused: true,
+    });
+  }
+
+  asSecondFocused(): LessonKey {
+    return new LessonKey({
+      ...this,
+      isSecondFocused: true,
     });
   }
 }
@@ -129,6 +141,10 @@ export class LessonKeys implements Iterable<LessonKey> {
     return [...this.#keys.values()].find((key) => key.isFocused) ?? null;
   }
 
+  findSecondFocusedKey(): LessonKey | null {
+    return [...this.#keys.values()].find((key) => key.isSecondFocused) ?? null;
+  }
+
   include({ codePoint }: Letter): void {
     this.#keys.set(codePoint, this.#keys.get(codePoint)!.asIncluded());
   }
@@ -143,6 +159,10 @@ export class LessonKeys implements Iterable<LessonKey> {
 
   focus({ codePoint }: Letter): void {
     this.#keys.set(codePoint, this.#keys.get(codePoint)!.asFocused());
+  }
+
+  focusSecond({ codePoint }: Letter): void {
+    this.#keys.set(codePoint, this.#keys.get(codePoint)!.asSecondFocused());
   }
 
   find(codePoint: CodePoint): LessonKey | null {

--- a/packages/keybr-lesson/lib/settings.ts
+++ b/packages/keybr-lesson/lib/settings.ts
@@ -20,6 +20,7 @@ export const lessonProps = {
       max: 1,
     }),
     recoverKeys: booleanProp("lesson.guided.recoverKeys", false),
+    trainSecondKey: booleanProp("lesson.guided.trainSecondKey", false),
   } as const,
   wordList: {
     wordListSize: numberProp("lesson.wordList.wordListSize", 1000, {

--- a/packages/keybr-lesson/lib/text/words.test.ts
+++ b/packages/keybr-lesson/lib/text/words.test.ts
@@ -1,7 +1,12 @@
 import { test } from "node:test";
 import { FakeRNGStream } from "@keybr/rand";
 import { equal, isNull } from "rich-assert";
-import { randomWords, uniqueWords, wordSequence } from "./words.ts";
+import {
+  interleavedWords,
+  randomWords,
+  uniqueWords,
+  wordSequence,
+} from "./words.ts";
 
 test("random words", () => {
   const rng = FakeRNGStream(3);
@@ -29,6 +34,36 @@ test("word sequence", () => {
   equal(cursor.wordIndex, 3);
   equal(wordSequence(wordList, cursor)(), "a");
   equal(cursor.wordIndex, 1);
+});
+
+test("interleaved words", () => {
+  const rng = FakeRNGStream(4); // 0, 0.25, 0.5, 0.75, ...
+
+  const words = interleavedWords(
+    wordSequence(["main1", "main2", "main3", "main4"], { wordIndex: 0 }),
+    wordSequence(["extra1", "extra2"], { wordIndex: 0 }),
+    0.5,
+    rng,
+  );
+
+  equal(words(), "extra1"); // 0 < 0.5
+  equal(words(), "extra2"); // 0.25 < 0.5
+  equal(words(), "main1"); // 0.5 is not < 0.5
+  equal(words(), "main2"); // 0.75 is not < 0.5
+});
+
+test("interleaved words falls back to the main generator when the extra generator is exhausted", () => {
+  const rng = FakeRNGStream(2);
+
+  const words = interleavedWords(
+    wordSequence(["main1", "main2"], { wordIndex: 0 }),
+    wordSequence([], { wordIndex: 0 }),
+    1,
+    rng,
+  );
+
+  equal(words(), "main1");
+  equal(words(), "main2");
 });
 
 test("unique words", () => {

--- a/packages/keybr-lesson/lib/text/words.ts
+++ b/packages/keybr-lesson/lib/text/words.ts
@@ -51,6 +51,23 @@ export function wordSequence(
   };
 }
 
+export function interleavedWords(
+  mainWords: WordGenerator,
+  extraWords: WordGenerator,
+  probability: number,
+  random: RNG,
+): WordGenerator {
+  return () => {
+    if (random() < probability) {
+      const word = extraWords();
+      if (word != null && word !== "") {
+        return word;
+      }
+    }
+    return mainWords();
+  };
+}
+
 export function uniqueWords(nextWord: WordGenerator): WordGenerator {
   let last = "";
   return () => {

--- a/packages/keybr-theme-designer/lib/design/LessonKeysPreview.tsx
+++ b/packages/keybr-theme-designer/lib/design/LessonKeysPreview.tsx
@@ -22,6 +22,7 @@ export function LessonKeysPreview() {
               bestConfidence: value,
               isIncluded: true,
               isFocused: value === 0.0,
+              isSecondFocused: value === 0.1,
               isForced: false,
             })
           }

--- a/packages/keybr-themes/lib/themes/theme.less
+++ b/packages/keybr-themes/lib/themes/theme.less
@@ -25,6 +25,7 @@
   --LessonKey--uncalibrated__background-color: var(--primary-d1);
   --LessonKey--uncalibrated__outline-color: transparent;
   --LessonKey--focused__outline-color: var(--secondary-l2);
+  --LessonKey--secondFocused__outline-color: var(--accent);
   --LessonKey--forced__outline-color: transparent;
   --LessonKey--current__outline-color: var(--secondary-l2);
 

--- a/packages/page-practice/lib/settings/lesson/GuidedLessonSettings.tsx
+++ b/packages/page-practice/lib/settings/lesson/GuidedLessonSettings.tsx
@@ -10,6 +10,7 @@ import { RecoverKeysProp } from "./RecoverKeysProp.tsx";
 import { RepeatWordsProp } from "./RepeatWordsProp.tsx";
 import { TargetSpeedProp } from "./TargetSpeedProp.tsx";
 import { TextManglingProp } from "./TextManglingProp.tsx";
+import { TrainSecondKeyProp } from "./TrainSecondKeyProp.tsx";
 
 export function GuidedLessonSettings({
   lesson,
@@ -37,6 +38,7 @@ export function GuidedLessonSettings({
         <RecoverKeysProp />
         <KeyboardOrderProp />
         <NaturalWordsProp />
+        <TrainSecondKeyProp />
         <RepeatWordsProp />
         <AlphabetSizeProp />
         <TextManglingProp />

--- a/packages/page-practice/lib/settings/lesson/TrainSecondKeyProp.tsx
+++ b/packages/page-practice/lib/settings/lesson/TrainSecondKeyProp.tsx
@@ -1,0 +1,44 @@
+import { lessonProps } from "@keybr/lesson";
+import { useSettings } from "@keybr/settings";
+import {
+  CheckBox,
+  Description,
+  Explainer,
+  Field,
+  FieldList,
+} from "@keybr/widget";
+import { type ReactNode } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+export function TrainSecondKeyProp(): ReactNode {
+  const { formatMessage } = useIntl();
+  const { settings, updateSettings } = useSettings();
+  return (
+    <>
+      <FieldList>
+        <Field>
+          <CheckBox
+            label={formatMessage({
+              id: "settings.trainSecondKey.label",
+              defaultMessage: "Train second key",
+            })}
+            checked={settings.get(lessonProps.guided.trainSecondKey)}
+            onChange={(value) => {
+              updateSettings(
+                settings.set(lessonProps.guided.trainSecondKey, value),
+              );
+            }}
+          />
+        </Field>
+      </FieldList>
+      <Explainer>
+        <Description>
+          <FormattedMessage
+            id="settings.trainSecondKey.description"
+            defaultMessage="Occasionally mix in words for a second key alongside the one you are focused on: the next letter to unlock, or, once every letter is unlocked, your second-weakest key."
+          />
+        </Description>
+      </Explainer>
+    </>
+  );
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from "@playwright/test";
+
+try {
+  process.loadEnvFile(".env");
+} catch (err: any) {
+  if (err.code !== "ENOENT") {
+    throw err;
+  }
+}
+
+// Unset by default, so Playwright falls back to its own installed browser
+// (`npx playwright install chromium`); set locally to point at some other
+// chromium build instead
+const executablePath = process.env.PLAYWRIGHT_CHROMIUM_PATH ?? undefined;
+
+// Launch arguments for the test run
+const launchArgs = process.env.PLAYWRIGHT_LAUNCH_ARGS?.split(",") ?? [];
+
+// Base URL to test against
+const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: 0,
+  reporter: "list",
+  use: {
+    baseURL,
+    launchOptions: {
+      executablePath,
+      args: launchArgs,
+    },
+  },
+  projects: [
+    {
+      name: "smoke",
+      testMatch: "smoke.spec.ts",
+    },
+    {
+      name: "e2e",
+      testMatch: "guided-lesson/**/*.spec.ts",
+      dependencies: ["smoke"],
+    },
+  ],
+  webServer: {
+    // CSS module class names (used throughout these tests as selectors)
+    // are only human-readable in a development build; a stale production
+    // build would make every selector silently fail to match.
+    command: "npm run build-dev && npm start",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});


### PR DESCRIPTION
This PR adds a "Train second key" option to the guided lesson settings. When enabled this mixes in with 20% probability either the next letter to train or the second-weakest letter for a user when all letters are unlocked.

I've increased my target typing speed for a layout and I found that when I had finally mastered a target key, the next key lessons would break that momentum and the previously unlocked key would lag again, causing a yo-yo between the two to happen.

Samples taken from the next-key are not factored into unlocking it, the words are only there to accustom the user to the motion of the next key.