### PR TITLE
tests: add Playwright E2E fuzz test for the guided lesson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,9 @@ sandbox/
 *.bak
 *~
 
+# Playwright
+test-results/
+playwright-report/
+
 # Custom scripts
 deploy.sh

--- a/e2e/guided-lesson/alphabet-size-churn.spec.ts
+++ b/e2e/guided-lesson/alphabet-size-churn.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+import {
+  announcedCodePoints,
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  mulberry32,
+  randomDelay,
+  readAppliedSettings,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+test("alphabetSize > 0 force-includes several keys at once", async ({
+  page,
+}) => {
+  // Sized for the keystroke budget's worst case, not just the typical
+  // case, so an unlucky seed fails its own assertion, not a timeout.
+  test.setTimeout(5 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(
+    `alphabetSize churn seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`,
+  );
+  const random = mulberry32(seed);
+  const SETUP_KEYSTROKE_BUDGET = 3000;
+  const ALPHABET_SIZE = 0.3;
+  const minSize = 6;
+
+  const baseSettings = {
+    "lesson.type": "guided",
+    "keyboard.layout": "en-us",
+  };
+  await page.addInitScript((settings) => {
+    localStorage.setItem("settings", JSON.stringify(settings));
+  }, baseSettings);
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  const maxSize =
+    minSize + Math.round((alphabet.length - minSize) * ALPHABET_SIZE);
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+
+  // Get a few keys included first, to check continuity across the churn.
+  while (
+    keystrokes < SETUP_KEYSTROKE_BUDGET &&
+    alphabet.filter((cp) => keys.get(cp)!.included).length < 7
+  ) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const cp of alphabet) {
+      if (keys.get(cp)!.included && !next.get(cp)!.included) {
+        throw new Error(
+          `Key ${cp} regressed before churning alphabetSize after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    keys = next;
+  }
+  const includedBefore = alphabet.filter((cp) => keys.get(cp)!.included);
+  expect(
+    includedBefore.length,
+    `expected at least 7 keys included before churning alphabetSize within ${SETUP_KEYSTROKE_BUDGET} keystrokes (seed ${seed})`,
+  ).toBeGreaterThanOrEqual(7);
+
+  // addInitScript, not evaluate: the base settings init script above
+  // reruns on every navigation including reload, clobbering a plain write.
+  await page.addInitScript(
+    (settings) => {
+      localStorage.setItem("settings", JSON.stringify(settings));
+    },
+    { ...baseSettings, "lesson.guided.alphabetSize": ALPHABET_SIZE },
+  );
+  await page.reload();
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  expect(
+    (await readAppliedSettings(page))["lesson.guided.alphabetSize"],
+    `expected the alphabetSize change to have actually taken effect (seed ${seed})`,
+  ).toBe(ALPHABET_SIZE);
+
+  // GuidedLesson.update() rebuilds LessonKeys from scratch every call, so
+  // this applies the instant the page (re)mounts - no typing needed.
+  const afterReload = await snapshotKeys(page);
+  const includedAfter = alphabet.filter((cp) => afterReload.get(cp)!.included);
+  const forcedAfter = alphabet.filter((cp) => afterReload.get(cp)!.forced);
+  const announcedAfter = await announcedCodePoints(page);
+  // Progress replays persisted results through append() with a no-op
+  // listener (progress.ts's seed()/seedAsync()), so nothing included this
+  // way, forced or not, ever gets a "New letter unlocked" toast.
+  for (const cp of forcedAfter) {
+    expect(
+      announcedAfter,
+      `expected no "New letter unlocked" toast for forced key ${cp} (seed ${seed})`,
+    ).not.toContain(cp);
+  }
+
+  for (const cp of includedBefore) {
+    expect(
+      afterReload.get(cp)!.included,
+      `expected previously-included key ${cp} to still be included after raising alphabetSize (seed ${seed})`,
+    ).toBe(true);
+  }
+  expect(
+    includedAfter.length,
+    `expected at least ${Math.min(maxSize, alphabet.length)} keys included once alphabetSize forces up to maxSize=${maxSize} (seed ${seed})`,
+  ).toBeGreaterThanOrEqual(Math.min(maxSize, alphabet.length));
+  expect(
+    forcedAfter.length,
+    `expected some forced keys once alphabetSize is ${ALPHABET_SIZE} (seed ${seed})`,
+  ).toBeGreaterThan(0);
+  expect(
+    forcedAfter.length,
+    `expected at most maxSize-minSize=${maxSize - minSize} forced keys (seed ${seed})`,
+  ).toBeLessThanOrEqual(maxSize - minSize);
+  for (const cp of forcedAfter) {
+    expect(
+      afterReload.get(cp)!.uncalibrated,
+      `expected freshly-forced key ${cp} to be uncalibrated (seed ${seed})`,
+    ).toBe(true);
+  }
+});

--- a/e2e/guided-lesson/alphabet-unlock.spec.ts
+++ b/e2e/guided-lesson/alphabet-unlock.spec.ts
@@ -1,0 +1,189 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+  announcedCodePoints,
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  type KeySnapshot,
+  MAX_KEYSTROKES,
+  mulberry32,
+  randomDelay,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+const CURRENT_KEY_SELECTOR = '[id*="currentKey"] [data-code-point]';
+
+test("typing through the full American English alphabet never regresses an unlocked key", async ({
+  page,
+}) => {
+  // Scoped to this test only, since a fuzz test's worst-case runtime
+  // varies a lot by seed - the other tests should keep failing fast.
+  test.setTimeout(15 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(`fuzz seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`);
+  const random = mulberry32(seed);
+
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  expect(alphabet.length).toBeGreaterThan(0);
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+  // True once past the initial minSize batch, when only one key is ever
+  // sub-threshold at a time and "target only advances" becomes guaranteed.
+  let bootstrapped = false;
+  let previousFocused: string | null = null;
+  const seenFocused = new Set<string>();
+
+  for (const codePoint of alphabet) {
+    if (keys.get(codePoint)!.included) {
+      expect(
+        keys.get(codePoint)!.uncalibrated,
+        `expected initially-included key ${codePoint} to start uncalibrated (seed ${seed})`,
+      ).toBe(true);
+    }
+  }
+
+  while (keystrokes < MAX_KEYSTROKES && !allIncluded(keys, alphabet)) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const codePoint of alphabet) {
+      if (keys.get(codePoint)!.included && !next.get(codePoint)!.included) {
+        throw new Error(
+          `Key ${codePoint} regressed from included to excluded after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    // Only holds with default alphabetSize: 0 / recoverKeys: false;
+    // GuidedLesson.update() can force several keys at once otherwise.
+    const newlyIncluded = alphabet.filter(
+      (cp) => !keys.get(cp)!.included && next.get(cp)!.included,
+    );
+    expect(
+      newlyIncluded.length,
+      `expected at most one newly-included key per round, got [${newlyIncluded}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toBeLessThanOrEqual(1);
+
+    // The "force" branch only triggers when alphabetSize > 0.
+    const forced = alphabet.filter((cp) => next.get(cp)!.forced);
+    expect(
+      forced,
+      `expected no forced keys under default alphabetSize: 0, got [${forced}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toEqual([]);
+
+    // "Current key" must match the key set's own focused key, and be
+    // included.
+    const focusedInSet = alphabet.filter((cp) => next.get(cp)!.focused);
+    const currentFocused = await currentKeyCodePoint(page);
+    expect(
+      focusedInSet.length,
+      `expected at most one focused key in the key set, got [${focusedInSet}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toBeLessThanOrEqual(1);
+    expect(
+      focusedInSet,
+      `"Current key" (${currentFocused}) doesn't match the key set's focused key(s) [${focusedInSet}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toEqual(currentFocused == null ? [] : [currentFocused]);
+    if (currentFocused != null) {
+      expect(
+        next.get(currentFocused)!.included,
+        `target key ${currentFocused} isn't marked included after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toBe(true);
+    }
+
+    // A freshly-included key starts uncalibrated (weakest), so it must
+    // immediately become the target.
+    if (newlyIncluded.length === 1) {
+      expect(
+        currentFocused,
+        `expected the newly-included key ${newlyIncluded[0]} to become the new target key, but the target key is ${currentFocused} after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toEqual(newlyIncluded[0]);
+
+      // Toaster.tsx renders newest-first, so index 0 is this round's toast.
+      const announced = await announcedCodePoints(page);
+      expect(
+        announced[0],
+        `expected the newest "New letter unlocked" toast to be for ${newlyIncluded[0]}, got toasts for [${announced}] after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toEqual(newlyIncluded[0]);
+
+      expect(
+        next.get(newlyIncluded[0])!.uncalibrated,
+        `expected freshly-included key ${newlyIncluded[0]} to start uncalibrated (no samples yet) after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toBe(true);
+
+      bootstrapped = true;
+    }
+
+    if (bootstrapped && currentFocused !== previousFocused) {
+      if (previousFocused != null) {
+        expect(
+          next.get(previousFocused)!.uncalibrated,
+          `expected ${previousFocused} to have accumulated real timing samples before the target moved on, but it's still uncalibrated after ${keystrokes} keystrokes (seed ${seed})`,
+        ).toBe(false);
+      }
+      if (currentFocused != null) {
+        expect(
+          seenFocused.has(currentFocused),
+          `target key moved back to ${currentFocused}, which was already the target key earlier - it should only ever advance, never return, after ${keystrokes} keystrokes (seed ${seed})`,
+        ).toBe(false);
+        seenFocused.add(currentFocused);
+      }
+      previousFocused = currentFocused;
+    }
+
+    keys = next;
+  }
+
+  const stillExcluded = alphabet.filter((cp) => !keys.get(cp)!.included);
+  expect(
+    stillExcluded,
+    `alphabet not fully unlocked within ${MAX_KEYSTROKES} keystrokes (seed ${seed}); still excluded: [${stillExcluded}]`,
+  ).toEqual([]);
+});
+
+function allIncluded(
+  keys: Map<string, KeySnapshot>,
+  alphabet: readonly string[],
+): boolean {
+  return alphabet.every((cp) => keys.get(cp)!.included);
+}
+
+async function currentKeyCodePoint(page: Page): Promise<string | null> {
+  const locator = page.locator(CURRENT_KEY_SELECTOR);
+  if ((await locator.count()) === 0) {
+    return null;
+  }
+  return locator.first().getAttribute("data-code-point");
+}

--- a/e2e/guided-lesson/alphabet-unlock.spec.ts
+++ b/e2e/guided-lesson/alphabet-unlock.spec.ts
@@ -10,9 +10,12 @@ import {
   roundTextSignature,
   sendChar,
   snapshotKeys,
+  SPACE_GLYPHS,
 } from "./helpers.ts";
 
 const CURRENT_KEY_SELECTOR = '[id*="currentKey"] [data-code-point]';
+const CURRENT_KEY_DETAILS_SELECTOR = '[id*="currentKey"] [class*="keyDetails"]';
+const FUMBLE_PROBABILITY = 0.15;
 
 test("typing through the full American English alphabet never regresses an unlocked key", async ({
   page,
@@ -68,11 +71,37 @@ test("typing through the full American English alphabet never regresses an unloc
       .locator(CURSOR_SELECTOR)
       .first()
       .textContent();
-    await sendChar(page, displayedChar ?? "");
+    const targetBeforeChar = await currentKeyCodePoint(page);
+    const detailsBeforeChar =
+      targetBeforeChar != null ? await currentKeyDetailsText(page) : null;
+    const fumbled = random() < FUMBLE_PROBABILITY;
+    if (fumbled) {
+      await fumbleThenCorrect(page, displayedChar ?? "", random);
+    } else {
+      await sendChar(page, displayedChar ?? "");
+    }
     keystrokes++;
     await page.waitForTimeout(delay);
 
     const signature = await roundTextSignature(page);
+    if (fumbled && targetBeforeChar != null) {
+      const targetAfterChar = await currentKeyCodePoint(page);
+      if (
+        targetAfterChar === targetBeforeChar &&
+        // The fumble's correct char may complete the round; appending a
+        // Result updates this key's samples from its other occurrences.
+        signature === roundSignature
+      ) {
+        // Histogram.from() skips a typo'd step's timing sample, so a
+        // fumble must not move this key's confidence.
+        const detailsAfterChar = await currentKeyDetailsText(page);
+        expect(
+          detailsAfterChar,
+          `expected fumbling ${targetBeforeChar} not to change its reported confidence (a miss records no timing sample), but it went from "${detailsBeforeChar}" to "${detailsAfterChar}" after ${keystrokes} keystrokes (seed ${seed})`,
+        ).toEqual(detailsBeforeChar);
+      }
+    }
+
     if (signature === roundSignature) {
       continue;
     }
@@ -186,4 +215,35 @@ async function currentKeyCodePoint(page: Page): Promise<string | null> {
     return null;
   }
   return locator.first().getAttribute("data-code-point");
+}
+
+async function currentKeyDetailsText(page: Page): Promise<string | null> {
+  const locator = page.locator(CURRENT_KEY_DETAILS_SELECTOR);
+  if ((await locator.count()) === 0) {
+    return null;
+  }
+  return locator.first().textContent();
+}
+
+const ALPHANUMERIC_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+function randomAlphanumericChar(random: () => number, exclude: string): string {
+  let char: string;
+  do {
+    char = ALPHANUMERIC_CHARS[Math.floor(random() * ALPHANUMERIC_CHARS.length)];
+  } while (char === exclude);
+  return char;
+}
+
+// TextInput.appendChar() never turns a wrong char into a step; only the
+// following correct char does, tagged Attr.Miss.
+async function fumbleThenCorrect(
+  page: Page,
+  displayed: string,
+  random: () => number,
+): Promise<void> {
+  const correct = SPACE_GLYPHS.has(displayed) ? " " : displayed;
+  const wrong = randomAlphanumericChar(random, correct);
+  await page.keyboard.type(wrong);
+  await sendChar(page, displayed);
 }

--- a/e2e/guided-lesson/daily-goal-toast.spec.ts
+++ b/e2e/guided-lesson/daily-goal-toast.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import {
+  CURSOR_SELECTOR,
+  MAX_KEYSTROKES,
+  roundTextSignature,
+  sendChar,
+  TOASTER_SELECTOR,
+} from "./helpers.ts";
+
+test("reaching the daily goal shows a 'Daily goal reached!' toast", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+        // Minutes; tiny so the goal is crossed the instant the first
+        // round's Result is recorded.
+        "lesson.dailyGoal": 0.001,
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const cursor = page.locator(CURSOR_SELECTOR).first();
+  let roundSignature = await roundTextSignature(page);
+  for (
+    let i = 0;
+    i < MAX_KEYSTROKES && (await roundTextSignature(page)) === roundSignature;
+    i++
+  ) {
+    const displayed = await cursor.textContent();
+    await sendChar(page, displayed ?? "");
+    // Histogram.validateSample() rejects samples under 40ms as implausibly
+    // fast (anti-cheat), which would make the whole Result invalid.
+    await page.waitForTimeout(50);
+  }
+
+  await expect(
+    page.locator(TOASTER_SELECTOR).getByText("Daily goal reached!"),
+  ).toBeVisible();
+});

--- a/e2e/guided-lesson/helpers.ts
+++ b/e2e/guided-lesson/helpers.ts
@@ -1,0 +1,81 @@
+import { type Page } from "@playwright/test";
+import Rand, { PRNG } from "rand-seed";
+
+export const CURSOR_SELECTOR = '[class*="chars-module__cursor"]';
+export const KEY_SET_SELECTOR = '[id*="keySet"] [data-code-point]';
+export const TOASTER_SELECTOR = '[class*="Toaster-module__toaster"]';
+export const ANNOUNCEMENT_KEY_SELECTOR = `${TOASTER_SELECTOR} [data-code-point]`;
+// Scoped past the TextArea wrapper, whose own status messages flicker
+// independently of the round.
+export const ROUND_SIGNATURE_SELECTOR = '[class*="TextLines-module__root"]';
+
+export const MAX_KEYSTROKES = 10000;
+export const MIN_DELAY_MS = 5;
+export const MAX_DELAY_MS = 60;
+
+// chars.tsx's specialChar() substitutes these for whitespace; map back to a
+// real space to send.
+export const SPACE_GLYPHS = new Set(["\u00A0", "\uE000", "\uE001"]); // nbsp, bullet, bar
+
+// Deterministic PRNG so a failing run's seed can be logged and replayed.
+export function mulberry32(seed: number): () => number {
+  const rand = new Rand(String(seed), PRNG.mulberry32);
+  return () => rand.next();
+}
+
+export function randomDelay(random: () => number): number {
+  return MIN_DELAY_MS + random() * (MAX_DELAY_MS - MIN_DELAY_MS);
+}
+
+export type KeySnapshot = {
+  readonly included: boolean;
+  readonly focused: boolean;
+  readonly uncalibrated: boolean;
+  readonly forced: boolean;
+};
+
+export async function snapshotKeys(
+  page: Page,
+): Promise<Map<string, KeySnapshot>> {
+  const entries = await page.locator(KEY_SET_SELECTOR).evaluateAll((els) =>
+    els.map((el) => [
+      el.getAttribute("data-code-point")!,
+      {
+        included: el.className.includes("lessonKey_included"),
+        focused: el.className.includes("lessonKey_focused"),
+        uncalibrated: el.className.includes("lessonKey_uncalibrated"),
+        forced: el.className.includes("lessonKey_forced"),
+      },
+    ]),
+  );
+  return new Map(entries as [string, KeySnapshot][]);
+}
+
+export async function announcedCodePoints(page: Page): Promise<string[]> {
+  return page
+    .locator(ANNOUNCEMENT_KEY_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+}
+
+// Confirms a settings change reached localStorage - a downstream-effect
+// invariant alone can pass even when the write silently no-ops.
+export async function readAppliedSettings(
+  page: Page,
+): Promise<Record<string, unknown>> {
+  const raw = await page.evaluate(() => localStorage.getItem("settings"));
+  return raw == null ? {} : JSON.parse(raw);
+}
+
+export async function roundTextSignature(page: Page): Promise<string> {
+  return page
+    .locator(ROUND_SIGNATURE_SELECTOR)
+    .evaluate((el) => el.textContent ?? "");
+}
+
+export async function sendChar(page: Page, displayed: string): Promise<void> {
+  if (SPACE_GLYPHS.has(displayed)) {
+    await page.keyboard.type(" ");
+  } else {
+    await page.keyboard.type(displayed);
+  }
+}

--- a/e2e/guided-lesson/mistake-color.spec.ts
+++ b/e2e/guided-lesson/mistake-color.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { CURSOR_SELECTOR, sendChar } from "./helpers.ts";
+
+test("a corrected mistake renders in the miss color", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const cursor = page.locator(CURSOR_SELECTOR).first();
+  const expected = (await cursor.textContent()) ?? "";
+  const wrong = expected === "j" ? "k" : "j";
+
+  // Default settings reject a single wrong keystroke without moving the
+  // cursor (TextInput.appendChar()).
+  await page.keyboard.type(wrong);
+  await expect(cursor).toHaveText(expected);
+
+  await sendChar(page, expected);
+
+  // A step preceded by a typo is marked Attr.Miss even once corrected,
+  // rendered as its own single-character span right before the cursor.
+  // Asserted via this sibling rather than "cursor text changed", since the
+  // round's own (unseeded) text can repeat expected right after itself.
+  const missed = page
+    .locator(CURSOR_SELECTOR)
+    .locator("xpath=preceding-sibling::*[1]");
+  await expect(missed).toHaveText(expected);
+  const color = await missed.evaluate((el) => (el as HTMLElement).style.color);
+  expect(color).toBe("var(--textinput--miss__color)");
+});

--- a/e2e/guided-lesson/pointer-highlight.spec.ts
+++ b/e2e/guided-lesson/pointer-highlight.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+import { CURSOR_SELECTOR, sendChar, SPACE_GLYPHS } from "./helpers.ts";
+
+const POINTER_SELECTOR = '[class*="PointersLayer-module__pointer"]';
+
+test("the highlighted next key points at the correct on-screen key", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "settings",
+      JSON.stringify({
+        "lesson.type": "guided",
+        "keyboard.layout": "en-us",
+        "keyboard.pointers": true,
+      }),
+    );
+  });
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const cursor = page.locator(CURSOR_SELECTOR).first();
+  const KEYS_TO_CHECK = 5;
+  for (let i = 0; i < KEYS_TO_CHECK; i++) {
+    const displayed = (await cursor.textContent()) ?? "";
+    const expectedKeyId = SPACE_GLYPHS.has(displayed)
+      ? "Space"
+      : `Key${displayed.toUpperCase()}`;
+
+    // The pointer only appears after some hesitation delay, so poll
+    // rather than assume a fixed one.
+    const pointer = page.locator(POINTER_SELECTOR).first();
+    await expect(pointer).toBeVisible({ timeout: 5000 });
+    // It fades in via an SVG animation; let it settle before measuring.
+    await page.waitForTimeout(200);
+    const pointerBox = await pointer.boundingBox();
+    const keyBox = await page
+      .locator(`[data-key="${expectedKeyId}"]`)
+      .boundingBox();
+    expect(pointerBox, "pointer circle has no bounding box").not.toBeNull();
+    expect(
+      keyBox,
+      `no on-screen key found for ${expectedKeyId}`,
+    ).not.toBeNull();
+
+    const cx = pointerBox!.x + pointerBox!.width / 2;
+    const cy = pointerBox!.y + pointerBox!.height / 2;
+    expect(
+      cx >= keyBox!.x && cx <= keyBox!.x + keyBox!.width,
+      `expected pointer center x=${cx} to fall within key ${expectedKeyId}'s box [${keyBox!.x}, ${keyBox!.x + keyBox!.width}]`,
+    ).toBe(true);
+    expect(
+      cy >= keyBox!.y && cy <= keyBox!.y + keyBox!.height,
+      `expected pointer center y=${cy} to fall within key ${expectedKeyId}'s box [${keyBox!.y}, ${keyBox!.y + keyBox!.height}]`,
+    ).toBe(true);
+
+    await sendChar(page, displayed);
+    // Otherwise the next iteration could check the pointer before the app
+    // has cleared this character's own pointer.
+    await expect(cursor).not.toHaveText(displayed);
+  }
+});

--- a/e2e/guided-lesson/recover-keys-churn.spec.ts
+++ b/e2e/guided-lesson/recover-keys-churn.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test } from "@playwright/test";
+import {
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  mulberry32,
+  randomDelay,
+  readAppliedSettings,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+test("recoverKeys allows a key to legitimately regress", async ({ page }) => {
+  // Sized for the keystroke budgets' worst case, not just the typical
+  // case, so an unlucky seed fails its own assertion, not a timeout.
+  test.setTimeout(6 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(
+    `recoverKeys churn seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`,
+  );
+  const random = mulberry32(seed);
+  const SETUP_KEYSTROKE_BUDGET = 3000;
+  const POST_CHURN_KEYSTROKE_BUDGET = 800;
+
+  const baseSettings = {
+    "lesson.type": "guided",
+    "keyboard.layout": "en-us",
+  };
+  await page.addInitScript((settings) => {
+    localStorage.setItem("settings", JSON.stringify(settings));
+  }, baseSettings);
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  // GuidedLesson.update() always includes these unconditionally, regardless
+  // of confidence or recoverKeys, so they can never legitimately regress.
+  const initialBatch = new Set(alphabet.slice(0, 6));
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+
+  while (
+    keystrokes < SETUP_KEYSTROKE_BUDGET &&
+    alphabet.filter((cp) => keys.get(cp)!.included).length < 7
+  ) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const cp of alphabet) {
+      if (keys.get(cp)!.included && !next.get(cp)!.included) {
+        throw new Error(
+          `Key ${cp} regressed before churning recoverKeys after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    keys = next;
+  }
+  expect(
+    alphabet.filter((cp) => keys.get(cp)!.included).length,
+    `expected at least 7 keys included before churning recoverKeys within ${SETUP_KEYSTROKE_BUDGET} keystrokes (seed ${seed})`,
+  ).toBeGreaterThanOrEqual(7);
+
+  // addInitScript, not evaluate: the base settings init script above
+  // reruns on every navigation including reload, clobbering a plain write.
+  await page.addInitScript(
+    (settings) => {
+      localStorage.setItem("settings", JSON.stringify(settings));
+    },
+    { ...baseSettings, "lesson.guided.recoverKeys": true },
+  );
+  await page.reload();
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  expect(
+    (await readAppliedSettings(page))["lesson.guided.recoverKeys"],
+    `expected the recoverKeys change to have actually taken effect (seed ${seed})`,
+  ).toBe(true);
+
+  keys = await snapshotKeys(page);
+  for (const cp of initialBatch) {
+    expect(
+      keys.get(cp)!.included,
+      `expected guaranteed initial key ${cp} to still be included right after enabling recoverKeys (seed ${seed})`,
+    ).toBe(true);
+  }
+
+  roundSignature = await roundTextSignature(page);
+  delay = randomDelay(random);
+  keystrokes = 0;
+  // recoverKeys uses live confidence, not bestConfidence, so a key beyond
+  // the initial batch can legitimately lose inclusion - not forced here.
+  let sawRegressionBeyondInitialBatch = false;
+
+  while (keystrokes < POST_CHURN_KEYSTROKE_BUDGET) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const cp of initialBatch) {
+      expect(
+        next.get(cp)!.included,
+        `expected guaranteed initial key ${cp} to never regress, even with recoverKeys, after ${keystrokes} keystrokes (seed ${seed})`,
+      ).toBe(true);
+    }
+    for (const cp of alphabet) {
+      if (
+        !initialBatch.has(cp) &&
+        keys.get(cp)!.included &&
+        !next.get(cp)!.included
+      ) {
+        sawRegressionBeyondInitialBatch = true;
+      }
+    }
+    // The "force" branch only triggers when alphabetSize > 0.
+    const forced = alphabet.filter((cp) => next.get(cp)!.forced);
+    expect(
+      forced,
+      `expected no forced keys under default alphabetSize: 0, got [${forced}] after ${keystrokes} keystrokes (seed ${seed})`,
+    ).toEqual([]);
+    keys = next;
+  }
+
+  console.log(
+    `recoverKeys regression observed beyond the initial batch: ${sawRegressionBeyondInitialBatch} (seed ${seed})`,
+  );
+});

--- a/e2e/guided-lesson/settings-churn.spec.ts
+++ b/e2e/guided-lesson/settings-churn.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "@playwright/test";
+import {
+  CURSOR_SELECTOR,
+  KEY_SET_SELECTOR,
+  mulberry32,
+  randomDelay,
+  readAppliedSettings,
+  roundTextSignature,
+  sendChar,
+  snapshotKeys,
+} from "./helpers.ts";
+
+test("progress survives mid-run settings changes and a target-speed ramp", async ({
+  page,
+}) => {
+  // Sized for the keystroke budget's worst case, not just the typical
+  // case, so an unlucky seed fails its own assertion, not a timeout.
+  test.setTimeout(6 * 60_000);
+
+  const seed = Number(process.env.FUZZ_SEED) || Date.now();
+  console.log(
+    `settings-churn seed: ${seed} (rerun with FUZZ_SEED=${seed} to replay)`,
+  );
+  const random = mulberry32(seed);
+  const CHURN_KEYSTROKE_BUDGET = 4000;
+
+  const baseSettings = {
+    "lesson.type": "guided",
+    "keyboard.layout": "en-us",
+    "lesson.targetSpeed": 75,
+  };
+  await page.addInitScript((settings) => {
+    localStorage.setItem("settings", JSON.stringify(settings));
+  }, baseSettings);
+
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+  await page.locator("textarea").first().focus();
+
+  const alphabet = await page
+    .locator(KEY_SET_SELECTOR)
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-code-point")!));
+  const initialBatch = new Set(alphabet.slice(0, 6));
+
+  let keys = await snapshotKeys(page);
+  let roundSignature = await roundTextSignature(page);
+  let delay = randomDelay(random);
+  let keystrokes = 0;
+
+  // naturalWords only affects word generation, not GuidedLesson.update()'s
+  // inclusion logic, so no regression is expected across this reload.
+  async function churnNaturalWords() {
+    const included = alphabet.filter((cp) => keys.get(cp)!.included);
+    const settings = {
+      ...baseSettings,
+      "lesson.guided.naturalWords": false,
+    };
+    // addInitScript, not evaluate: the base settings init script above
+    // reruns on every navigation including reload, clobbering a plain write.
+    await page.addInitScript((s) => {
+      localStorage.setItem("settings", JSON.stringify(s));
+    }, settings);
+    await page.reload();
+    await expect(page.locator("[data-code-point]").first()).toBeVisible();
+    await page.locator("textarea").first().focus();
+
+    expect(
+      (await readAppliedSettings(page))["lesson.guided.naturalWords"],
+      `expected the naturalWords change to have actually taken effect (seed ${seed})`,
+    ).toBe(false);
+
+    keys = await snapshotKeys(page);
+    for (const cp of included) {
+      expect(
+        keys.get(cp)!.included,
+        `expected key ${cp} to still be included after toggling naturalWords (seed ${seed})`,
+      ).toBe(true);
+    }
+  }
+
+  // Confidence is computed against the target, so raising it can
+  // legitimately re-lock a key beyond the guaranteed initial 6 - not
+  // asserted here; what must still hold is asserted below.
+  async function churnTargetSpeed(newTargetSpeed: number) {
+    const included = alphabet.filter((cp) => keys.get(cp)!.included);
+    const settings = {
+      ...baseSettings,
+      "lesson.guided.naturalWords": false,
+      "lesson.targetSpeed": newTargetSpeed,
+    };
+    await page.addInitScript((s) => {
+      localStorage.setItem("settings", JSON.stringify(s));
+    }, settings);
+    await page.reload();
+    await expect(page.locator("[data-code-point]").first()).toBeVisible();
+    await page.locator("textarea").first().focus();
+
+    expect(
+      (await readAppliedSettings(page))["lesson.targetSpeed"],
+      `expected the targetSpeed change to have actually taken effect (seed ${seed})`,
+    ).toBe(newTargetSpeed);
+
+    keys = await snapshotKeys(page);
+    for (const cp of alphabet) {
+      if (!included.includes(cp) && !initialBatch.has(cp)) {
+        expect(
+          keys.get(cp)!.included,
+          `expected key ${cp} not to newly qualify for inclusion just from raising the target speed to ${newTargetSpeed} (seed ${seed})`,
+        ).toBe(false);
+      }
+    }
+  }
+
+  let naturalWordsChurned = false;
+  let targetSpeedChurned = false;
+
+  while (
+    keystrokes < CHURN_KEYSTROKE_BUDGET &&
+    !(naturalWordsChurned && targetSpeedChurned)
+  ) {
+    const displayedChar = await page
+      .locator(CURSOR_SELECTOR)
+      .first()
+      .textContent();
+    await sendChar(page, displayedChar ?? "");
+    keystrokes++;
+    await page.waitForTimeout(delay);
+
+    const signature = await roundTextSignature(page);
+    if (signature === roundSignature) {
+      continue;
+    }
+    roundSignature = signature;
+    delay = randomDelay(random);
+
+    const next = await snapshotKeys(page);
+    for (const codePoint of alphabet) {
+      if (keys.get(codePoint)!.included && !next.get(codePoint)!.included) {
+        throw new Error(
+          `Key ${codePoint} regressed from included to excluded after ${keystrokes} keystrokes (seed ${seed})`,
+        );
+      }
+    }
+    keys = next;
+
+    const includedCount = alphabet.filter(
+      (cp) => keys.get(cp)!.included,
+    ).length;
+    if (!naturalWordsChurned && includedCount >= 7) {
+      await churnNaturalWords();
+      naturalWordsChurned = true;
+      roundSignature = await roundTextSignature(page);
+      delay = randomDelay(random);
+    } else if (
+      naturalWordsChurned &&
+      !targetSpeedChurned &&
+      includedCount >= 8
+    ) {
+      await churnTargetSpeed(300);
+      targetSpeedChurned = true;
+      roundSignature = await roundTextSignature(page);
+      delay = randomDelay(random);
+    }
+  }
+
+  expect(
+    naturalWordsChurned && targetSpeedChurned,
+    `expected both settings changes to be exercised within ${CHURN_KEYSTROKE_BUDGET} keystrokes (seed ${seed}); naturalWordsChurned=${naturalWordsChurned}, targetSpeedChurned=${targetSpeedChurned}`,
+  ).toBe(true);
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("practice page loads and accepts typed input", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("[data-code-point]").first()).toBeVisible();
+
+  await page.locator("textarea").first().focus();
+  const textArea = page.locator('[class*="TextArea-module__root"]');
+  const before = await textArea.innerHTML();
+
+  const expectedChar = await page
+    .locator('[class*="chars-module__cursor"]')
+    .first()
+    .textContent();
+  await page.keyboard.type(expectedChar ?? "");
+
+  await expect(async () => {
+    expect(await textArea.innerHTML()).not.toEqual(before);
+  }).toPass();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@formatjs/cli-lib": "^8.5.0",
         "@formatjs/ts-transformer": "^4.4.2",
         "@jdalton/patch-package": "^8.1.1",
+        "@playwright/test": "^1.62.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -85,6 +86,7 @@
         "postcss": "^8.5.8",
         "postcss-less": "^6.0.0",
         "prettier": "^3.8.1",
+        "rand-seed": "^3.0.0",
         "rich-assert": "^0.0.3",
         "source-map-loader": "^5.0.0",
         "stylelint": "^17.6.0",
@@ -1699,6 +1701,22 @@
       },
       "engines": {
         "node": ">=20.8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -8230,6 +8248,53 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -9028,6 +9093,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/rand-seed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rand-seed/-/rand-seed-3.0.0.tgz",
+      "integrity": "sha512-Zy8wnL6whyIAGOX2i9Mn1Orq3t9TNizGUk8euxamr60Z3PmspwFeT+vCZPcYMAR5nOztnAKPtVi3jt8EzmCB6g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rc": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "build-dev": "env NODE_ENV=development webpack",
     "watch": "env NODE_ENV=development webpack --watch",
     "start": "env NODE_ENV=development node --enable-source-maps ./root/index.js",
-    "start-docker": "env NODE_ENV=production ./packages/devenv/lib/initdb.ts && env NODE_ENV=production node --enable-source-maps ./root/index.js"
+    "start-docker": "env NODE_ENV=production ./packages/devenv/lib/initdb.ts && env NODE_ENV=production node --enable-source-maps ./root/index.js",
+    "test-e2e": "playwright test"
   },
   "dependencies": {
     "@fastr/client": "^0.1.3",
@@ -76,6 +77,7 @@
     "@formatjs/cli-lib": "^8.5.0",
     "@formatjs/ts-transformer": "^4.4.2",
     "@jdalton/patch-package": "^8.1.1",
+    "@playwright/test": "^1.62.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -104,6 +106,7 @@
     "postcss": "^8.5.8",
     "postcss-less": "^6.0.0",
     "prettier": "^3.8.1",
+    "rand-seed": "^3.0.0",
     "rich-assert": "^0.0.3",
     "source-map-loader": "^5.0.0",
     "stylelint": "^17.6.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from "@playwright/test";
+
+try {
+  process.loadEnvFile(".env");
+} catch (err: any) {
+  if (err.code !== "ENOENT") {
+    throw err;
+  }
+}
+
+// Unset by default, so Playwright falls back to its own installed browser
+// (`npx playwright install chromium`); set locally to point at some other
+// chromium build instead
+const executablePath = process.env.PLAYWRIGHT_CHROMIUM_PATH ?? undefined;
+
+// Launch arguments for the test run
+const launchArgs = process.env.PLAYWRIGHT_LAUNCH_ARGS?.split(",") ?? [];
+
+// Base URL to test against
+const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: 0,
+  reporter: "list",
+  use: {
+    baseURL,
+    launchOptions: {
+      executablePath,
+      args: launchArgs,
+    },
+  },
+  projects: [
+    {
+      name: "smoke",
+      testMatch: "smoke.spec.ts",
+    },
+    {
+      name: "e2e",
+      testMatch: "guided-lesson/**/*.spec.ts",
+      dependencies: ["smoke"],
+    },
+  ],
+  webServer: {
+    // CSS module class names (used throughout these tests as selectors)
+    // are only human-readable in a development build; a stale production
+    // build would make every selector silently fail to match.
+    command: "npm run build-dev && npm start",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});


### PR DESCRIPTION
This branch adds an end-to-end test suite with Playwright which exercises the guided lessons functionality.

Completes in about <5 minutes on my machine. I run this with:

```shell
export PLAYWRIGHT_BROWSERS_PATH="$(nix build nixpkgs#playwright-driver.browsers --no-link --print-out-paths)"
export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
npm run test-e2e
```